### PR TITLE
Add id property

### DIFF
--- a/src/rules/schema.js
+++ b/src/rules/schema.js
@@ -1,4 +1,5 @@
 export const sortClassMembersSchema = [{
+	id: 'https://github.com/bryanrsmith/eslint-plugin-sort-class-members/v1',
 	type: 'object',
 	properties: {
 		order: { '$ref': '#/definitions/order' },


### PR DESCRIPTION
The missing `id` property generates `can't resolve reference #/definitions/order from id #` errors in eslint v4.3.0 (latest release). 