### PR TITLE
feat(alphabetical): allow an optional alphabetic sort inside the order

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Members can be matched to positional slots using several criteria, including nam
 * `propertyType`: A subtype of `type: "property"` that can match the type of the property value. e.g., `propertyType: "ArrowFunctionExpression"` to match properties whose value is initialized to an arrow function.
 * `accessorPair`: `true|false`. True to match only getters and setters that are part of a pair. i.e., only those that have both `get` and `set` methods defined.
 * `static`: `true|false` to restrict the match to static or instance members.
+* `sort`: `"alphabetical"|"none"`. Used to require a specific sorting within the slot for matched members. Defaults to `"none"`.
 
 A few examples:
 
@@ -106,6 +107,7 @@ A few examples:
 * `{ "static": true }` would match all static methods and properties.
 * `{ "name": "/on.+/", "type": "method" }` would match both static and instance methods whose names start with "on".
 * `"/on.+/"` is shorthand for `{ "name": "/on.+/" }`, and would match all static and instance methods and properties whose names start with "on".
+* `{ "type": "method", "sort": "alphabetical" }` would match all methods, and enforce an alphabetical sort.
 
 **Note**: You can simply use a string if you only want to match on the name.
 

--- a/src/rules/schema.js
+++ b/src/rules/schema.js
@@ -31,6 +31,7 @@ export const sortClassMembersSchema = [
 								kind: { enum: ['get', 'set'] },
 								propertyType: { type: 'string' },
 								accessorPair: { type: 'boolean' },
+								sort: { enum: ['alphabetical', 'none'] },
 								static: { type: 'boolean' },
 							},
 							additionalProperties: false,

--- a/test/rules/sort-class-members.spec.js
+++ b/test/rules/sort-class-members.spec.js
@@ -39,6 +39,20 @@ const accessorPairCustomGroupOptions = [
 	},
 ];
 
+const alphabeticalOptions = [
+	{
+		order: ['[constructor]', '[methods]'],
+		groups: {
+			methods: [
+				{
+					sort: 'alphabetical',
+					type: 'method',
+				},
+			],
+		},
+	},
+];
+
 const objectOrderOptions = [
 	{
 		order: [
@@ -166,6 +180,10 @@ ruleTester.run('sort-class-members', rule, {
 		{
 			code: 'class A { get a(){} get b(){} set a(v){} }',
 			options: [{ order: ['everything-else'], accessorPairPositioning: 'any' }],
+		},
+		{
+			code: 'class A { constructor(){} a(){} b(){} c(){} }',
+			options: alphabeticalOptions,
 		},
 	],
 	invalid: [
@@ -354,6 +372,16 @@ ruleTester.run('sort-class-members', rule, {
 				},
 			],
 			options: [{ order: ['everything-else'], accessorPairPositioning: 'setThenGet' }],
+		},
+		{
+			code: 'class A { constructor(){} b(){} a(){} c(){} }',
+			errors: [
+				{
+					message: 'Expected method a to come before method b.',
+					type: 'MethodDefinition',
+				},
+			],
+			options: alphabeticalOptions,
 		},
 	],
 });


### PR DESCRIPTION
@bryanrsmith in our use of the plugin, we found a need to enforce alphabetical sorting inside the individual groupings, particularly for larger classes with a lot of functions.

Is this something that would be broadly useful to add back? Are there more tests or alterations that would help?