### PR TITLE
feat(async): add support for async methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,12 +99,14 @@ Members can be matched to positional slots using several criteria, including nam
 * `propertyType`: A subtype of `type: "property"` that can match the type of the property value. e.g., `propertyType: "ArrowFunctionExpression"` to match properties whose value is initialized to an arrow function.
 * `accessorPair`: `true|false`. True to match only getters and setters that are part of a pair. i.e., only those that have both `get` and `set` methods defined.
 * `static`: `true|false` to restrict the match to static or instance members.
+* `async`: `true|false` to restrict the match to async members.
 * `sort`: `"alphabetical"|"none"`. Used to require a specific sorting within the slot for matched members. Defaults to `"none"`.
 
 A few examples:
 
 * `{ "name": "create", "type": "method", "static": true }` would match a static method named `create`.
 * `{ "static": true }` would match all static methods and properties.
+* `{ "async": true }` would match all async methods.
 * `{ "name": "/on.+/", "type": "method" }` would match both static and instance methods whose names start with "on".
 * `"/on.+/"` is shorthand for `{ "name": "/on.+/" }`, and would match all static and instance methods and properties whose names start with "on".
 * `{ "type": "method", "sort": "alphabetical" }` would match all methods, and enforce an alphabetical sort.
@@ -121,6 +123,7 @@ The following groups are provided by default:
 * `[arrow-function-properties]`: matches properties whose value is initialized to an arrow function
 * `[methods]`: matches all methods
 * `[static-methods]`: matches all static methods
+* `[async-methods]`: matches all async methods
 * `[conventional-private-methods]`: matches methods whose name starts with an underscore
 * `[everything-else]`: matches all class members not matched by any other rule
 

--- a/src/rules/schema.js
+++ b/src/rules/schema.js
@@ -33,6 +33,7 @@ export const sortClassMembersSchema = [
 								accessorPair: { type: 'boolean' },
 								sort: { enum: ['alphabetical', 'none'] },
 								static: { type: 'boolean' },
+								async: { type: 'boolean' },
 							},
 							additionalProperties: false,
 						},

--- a/src/rules/sort-class-members.js
+++ b/src/rules/sort-class-members.js
@@ -125,6 +125,7 @@ function getMemberInfo(node, sourceCode) {
 	let name;
 	let type;
 	let propertyType;
+	let async = false;
 
 	if (node.type === 'ClassProperty') {
 		type = 'property';
@@ -134,9 +135,10 @@ function getMemberInfo(node, sourceCode) {
 	} else {
 		name = node.key.name;
 		type = 'method';
+		async = node.value && node.value.async;
 	}
 
-	return { name, type, static: node.static, kind: node.kind, propertyType, node };
+	return { name, type, static: node.static, async, kind: node.kind, propertyType, node };
 }
 
 function findAccessorPairProblems(members, positioning) {
@@ -322,6 +324,7 @@ const builtInGroups = {
 	'arrow-function-properties': { propertyType: 'ArrowFunctionExpression' },
 	methods: { type: 'method' },
 	'static-methods': { type: 'method', static: true },
+	'async-methods': { type: 'method', async: true },
 	'conventional-private-methods': { type: 'method', name: '/_.+/' },
 	'everything-else': {},
 };
@@ -330,6 +333,7 @@ const comparers = [
 	{ property: 'name', value: 100, test: (m, s) => s.testName(m.name) },
 	{ property: 'type', value: 10, test: (m, s) => s.type === m.type },
 	{ property: 'static', value: 10, test: (m, s) => s.static === m.static },
+	{ property: 'async', value: 10, test: (m, s) => s.async === m.async },
 	{ property: 'kind', value: 10, test: (m, s) => s.kind === m.kind },
 	{
 		property: 'accessorPair',

--- a/test/rules/sort-class-members.spec.js
+++ b/test/rules/sort-class-members.spec.js
@@ -59,6 +59,7 @@ const objectOrderOptions = [
 			{ type: 'method' },
 			{ type: 'property', name: '/_.+' },
 			{ type: 'method', static: true },
+			{ type: 'method', async: true },
 		],
 	},
 ];
@@ -149,7 +150,7 @@ ruleTester.run('sort-class-members', rule, {
 
 		// object config options
 		{
-			code: 'class A { a(){} _p = 1; static b(){} }',
+			code: 'class A { a(){} _p = 1; static b(){} async c(){} }',
 			parser: 'babel-eslint',
 			options: objectOrderOptions,
 		},
@@ -397,6 +398,19 @@ ruleTester.run('sort-class-members', rule, {
 				},
 			],
 			options: defaultOptions,
+		},
+
+		// object config options
+		{
+			code: 'class A { a(){} _p = 1; async b(){} static c(){} }',
+			parser: 'babel-eslint',
+			errors: [
+				{
+					message: 'Expected static method c to come before method b.',
+					type: 'MethodDefinition',
+				},
+			],
+			options: objectOrderOptions,
 		},
 	],
 });


### PR DESCRIPTION
@bryanrsmith in our use of the plugin, we found a need to add support for async methods.

Is this something that would be useful to add?