### PR TITLE
feat(decorators): add support for decorator groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Members can be matched to positional slots using several criteria, including nam
 * `static`: `true|false` to restrict the match to static or instance members.
 * `async`: `true|false` to restrict the match to async members.
 * `sort`: `"alphabetical"|"none"`. Used to require a specific sorting within the slot for matched members. Defaults to `"none"`.
+* `groupByDecorator`: a string used to group properties with the same decorator name (e.g. `observable` for `@observable`). Can be used together with `sort`. **Note**: Decorators are a Stage 2 proposal and require a custom parser like [babel-eslint](https://github.com/babel/babel-eslint).
 
 A few examples:
 

--- a/src/rules/schema.js
+++ b/src/rules/schema.js
@@ -27,6 +27,7 @@ export const sortClassMembersSchema = [
 							type: 'object',
 							properties: {
 								name: { type: 'string' },
+								groupByDecorator: { type: 'string' },
 								type: { enum: ['method', 'property'] },
 								kind: { enum: ['get', 'set'] },
 								propertyType: { type: 'string' },

--- a/src/rules/sort-class-members.js
+++ b/src/rules/sort-class-members.js
@@ -173,19 +173,30 @@ function getMemberInfo(node, sourceCode) {
 	let type;
 	let propertyType;
 	let async = false;
+	let decorators = [];
 
 	if (node.type === 'ClassProperty') {
 		type = 'property';
-		const [first, second] = sourceCode.getFirstTokens(node, 2);
+		const [first, second] = sourceCode.getFirstTokens(node.key, 2);
 		name = second && second.type === 'Identifier' ? second.value : first.value;
 		propertyType = node.value ? node.value.type : node.value;
+		decorators = (!!node.decorators && node.decorators.map(n => n.expression.name)) || [];
 	} else {
 		name = node.key.name;
 		type = 'method';
 		async = node.value && node.value.async;
 	}
 
-	return { name, type, static: node.static, async, kind: node.kind, propertyType, node };
+	return {
+		name,
+		type,
+		decorators,
+		static: node.static,
+		async,
+		kind: node.kind,
+		propertyType,
+		node,
+	};
 }
 
 function findAccessorPairProblems(members, positioning) {
@@ -381,6 +392,11 @@ const comparers = [
 	{ property: 'static', value: 10, test: (m, s) => s.static === m.static },
 	{ property: 'async', value: 10, test: (m, s) => s.async === m.async },
 	{ property: 'kind', value: 10, test: (m, s) => s.kind === m.kind },
+	{
+		property: 'groupByDecorator',
+		value: 10,
+		test: (m, s) => m.decorators.includes(s.groupByDecorator),
+	},
 	{
 		property: 'accessorPair',
 		value: 20,

--- a/test/rules/sort-class-members.spec.js
+++ b/test/rules/sort-class-members.spec.js
@@ -97,6 +97,24 @@ const propertyTypeOptions = [
 	},
 ];
 
+const decoratorOptions = [
+	{
+		order: ['[observables]', '[properties]'],
+		groups: {
+			observables: [{ type: 'property', groupByDecorator: 'observable' }],
+		},
+	},
+];
+
+const decoratorOptionsAlphabetical = [
+	{
+		order: ['[observables]', '[properties]'],
+		groups: {
+			observables: [{ type: 'property', groupByDecorator: 'observable', sort: 'alphabetical' }],
+		},
+	},
+];
+
 ruleTester.run('sort-class-members', rule, {
 	valid: [
 		{ code: 'class A {}', options: defaultOptions },
@@ -129,6 +147,21 @@ ruleTester.run('sort-class-members', rule, {
 			code: 'class A { foo = 1; bar = () => 2 }',
 			parser: require.resolve('babel-eslint'),
 			options: propertyTypeOptions,
+		},
+
+		// class properties with decorators
+		{
+			code: 'class A { @observable bar = 2; @observable baz = 1; foo = 3; constructor(){} }',
+			options: decoratorOptions,
+			parser: require.resolve('babel-eslint'),
+			parserOptions: { ecmaFeatures: { experimentalDecorators: true } },
+		},
+
+		{
+			code: 'class A { @observable bar = 2; @observable foo = 1; baz = 3; constructor(){} }',
+			options: decoratorOptions,
+			parser: require.resolve('babel-eslint'),
+			parserOptions: { ecmaFeatures: { experimentalDecorators: true } },
 		},
 
 		// regexp names
@@ -543,6 +576,32 @@ ruleTester.run('sort-class-members', rule, {
 				},
 			],
 			options: defaultOptions,
+			parser: require.resolve('babel-eslint'),
+			parserOptions: { ecmaFeatures: { experimentalDecorators: true } },
+		},
+		{
+			code: 'class A {  @observable bar = 2; baz = 3; @observable foo = 1; constructor(){} }',
+			output: 'class A {  @observable bar = 2; @observable foo = 1; baz = 3;  constructor(){} }',
+			errors: [
+				{
+					message: 'Expected property foo to come before property baz.',
+					type: 'ClassProperty',
+				},
+			],
+			options: decoratorOptions,
+			parser: require.resolve('babel-eslint'),
+			parserOptions: { ecmaFeatures: { experimentalDecorators: true } },
+		},
+		{
+			code: 'class A { @observable foo = 1; @observable bar = 2; constructor(){} }',
+			output: 'class A { @observable bar = 2; @observable foo = 1;  constructor(){} }',
+			errors: [
+				{
+					message: 'Expected property bar to come before property foo.',
+					type: 'ClassProperty',
+				},
+			],
+			options: decoratorOptionsAlphabetical,
 			parser: require.resolve('babel-eslint'),
 			parserOptions: { ecmaFeatures: { experimentalDecorators: true } },
 		},


### PR DESCRIPTION
Using this with MobX stores and noticed an issue where it reads the property name as being the decorator name (i.e `observable` instead of `bar` for `@observable bar;`) and it breaks the alphabetical order. 

I have also introduced a new property that can be used to group properties with the same decorator together while still keeping the ability to have them alphabetically sorted.

Let me know what you think and if it makes sense to be part of the plugin.