### PR TITLE
feat: add support for dynamic methods

### DIFF
--- a/src/rules/sort-class-members.js
+++ b/src/rules/sort-class-members.js
@@ -183,6 +183,11 @@ function getMemberInfo(node, sourceCode) {
 		decorators = (!!node.decorators && node.decorators.map(n => n.expression.name)) || [];
 	} else {
 		name = node.key.name;
+		if (!name) {
+		  const objectName = node.key.object ? node.key.object.name : '';
+		  const propertyName = node.key.property ? node.key.property.name : '';
+		  name = `[${objectName}${objectName && propertyName ? '.' : ''}${propertyName}]`;
+		}
 		type = 'method';
 		async = node.value && node.value.async;
 	}

--- a/test/rules/sort-class-members.spec.js
+++ b/test/rules/sort-class-members.spec.js
@@ -115,6 +115,19 @@ const decoratorOptionsAlphabetical = [
 	},
 ];
 
+const dynamicKeysCustomGroupOptions = [
+	{
+		order: ['[getters]', '[methods]', '[dynamic-name-methods]'],
+		groups: {
+			'dynamic-name-methods': [{
+				name: '/^\\[[^\\]]+\\]/',
+				type: 'method',
+				sort: 'alphabetical'
+			}],
+		},
+	},
+];
+
 ruleTester.run('sort-class-members', rule, {
 	valid: [
 		{ code: 'class A {}', options: defaultOptions },
@@ -617,5 +630,18 @@ ruleTester.run('sort-class-members', rule, {
 			],
 			options: objectOrderOptions,
 		},
+		// dynamic class names, https://github.com/bryanrsmith/eslint-plugin-sort-class-members/pull/59
+		{
+			code: `class A { [dynamic](){}\n[dynamic.name](){} get some(){}\n// documentation\nmethod(){}\n}`,
+			output: 'class A { get some(){}\n// documentation\nmethod(){}\n[dynamic](){}\n[dynamic.name](){}\n\n}',
+			errors: [
+				{
+					message: 'Expected dynamic named methods to come after method.',
+					type: 'MethodDefinition',
+				},
+			],
+			options: defaultOptions,
+		},
+		dynamicKeysCustomGroupOptions
 	],
 });


### PR DESCRIPTION
When method is defined by dynamic name as `[name]` or `[key.name]` then the plugin breaks eslint fix in whole file. This code is successfully tested in big multirepo containing many of these with config:
`order: [ '[brackets-methods]' ]`
and
`groups:{'brackets-methods': [{ name: '/^\\[[a-zA-Z0-9_\\.]+\\]/', type: 'method', sort: 'alphabetical' }]}`