### PR TITLE
Add support for call expression decorator

### DIFF
--- a/src/rules/sort-class-members.js
+++ b/src/rules/sort-class-members.js
@@ -181,6 +181,12 @@ function getMemberInfo(node, sourceCode) {
 		name = second && second.type === 'Identifier' ? second.value : first.value;
 		propertyType = node.value ? node.value.type : node.value;
 		decorators = (!!node.decorators && node.decorators.map(n => n.expression.name)) || [];
+		decorators =
+			(!!node.decorators &&
+				node.decorators.map(n =>
+					n.expression.type === 'CallExpression' ? n.expression.callee.name : n.expression.name
+				)) ||
+			[];
 	} else {
 		name = node.key.name;
 		type = 'method';

--- a/test/rules/sort-class-members.spec.js
+++ b/test/rules/sort-class-members.spec.js
@@ -99,9 +99,10 @@ const propertyTypeOptions = [
 
 const decoratorOptions = [
 	{
-		order: ['[observables]', '[properties]'],
+		order: ['[observables]', '[properties]', '[injects]'],
 		groups: {
 			observables: [{ type: 'property', groupByDecorator: 'observable' }],
+			injects: [{ type: 'property', groupByDecorator: 'Inject' }],
 		},
 	},
 ];
@@ -151,14 +152,16 @@ ruleTester.run('sort-class-members', rule, {
 
 		// class properties with decorators
 		{
-			code: 'class A { @observable bar = 2; @observable baz = 1; foo = 3; constructor(){} }',
+			code:
+				'class A { @observable bar = 2; @observable baz = 1; foo = 3; @Inject() hoge = 4; @observable @Inject() fuga = 5; constructor(){} }',
 			options: decoratorOptions,
 			parser: require.resolve('babel-eslint'),
 			parserOptions: { ecmaFeatures: { experimentalDecorators: true } },
 		},
 
 		{
-			code: 'class A { @observable bar = 2; @observable foo = 1; baz = 3; constructor(){} }',
+			code:
+				'class A { @observable bar = 2; @observable foo = 1; @Inject() @observable fuga = 5; baz = 3; constructor(){}; @Inject() hoge = 4; }',
 			options: decoratorOptions,
 			parser: require.resolve('babel-eslint'),
 			parserOptions: { ecmaFeatures: { experimentalDecorators: true } },
@@ -580,11 +583,17 @@ ruleTester.run('sort-class-members', rule, {
 			parserOptions: { ecmaFeatures: { experimentalDecorators: true } },
 		},
 		{
-			code: 'class A {  @observable bar = 2; baz = 3; @observable foo = 1; constructor(){} }',
-			output: 'class A {  @observable bar = 2; @observable foo = 1; baz = 3;  constructor(){} }',
+			code:
+				'class A {  @observable bar = 2; baz = 3; @Inject() hoge = 4; @observable foo = 1; @observable @Inject() fuga = 5; constructor(){} }',
+			output:
+				'class A {  @observable bar = 2; @observable foo = 1; baz = 3; @Inject() hoge = 4;  @observable @Inject() fuga = 5; constructor(){} }',
 			errors: [
 				{
 					message: 'Expected property foo to come before property baz.',
+					type: 'ClassProperty',
+				},
+				{
+					message: 'Expected property foo to come before property hoge.',
 					type: 'ClassProperty',
 				},
 			],


### PR DESCRIPTION
Fix #61 

As of the issue, `CallExpression` decorator is currently not supported.
This PR could solve the problem.

```typescript
// e.g.
// 'Identifier' decorator node
{
  type: 'Decorator',
  expression: {
    type: 'Identifier',
    name: 'observable',
    range: [ 310, 332 ],
    loc: { start: [Object], end: [Object] },
    parent: [Circular *1]
  },
  range: [ Array],
  ...
}

// 'Identifier' decorator node
{
  type: 'Decorator',
  expression: {
    type: 'CallExpression',
    callee: {
      type: 'Identifier',
      name: 'Inject',
      range: [Array],
      loc: [Object],
      parent: [Circular *1]
    },
    arguments: [],
    optional: false,
    range: [ 310, 332 ],
    loc: { start: [Object], end: [Object] },
    parent: [Circular *2]
  },
  range: [ Array],
  ...
}
```