### PR TITLE
feat(options): add support for localeCompare locale argument, upgrade string comparation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ The rule accepts the following configuration properties:
 - `groups`: May optionally be used to created customized named groups of members so that `order` can be more easily maintained. Groups can be referenced by name by using square brackets. E.g., `"[group-name]"`.
 - `accessorPairPositioning`: Used to specify the required positioning of get/set pairs. Available values: `getThenSet`, `setThenGet`, `together`, `any`.
 - `stopAfterFirstProblem`: Only report the first sort problem in each class (plus the number of problems found). Useful if you only want to know that the class has sort problems without spamming error messages. The default is `false`.
+- `locale`: Used to specify the second argument of class member names comparsion function [localeCompare](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare#using_locales). The default is `en-US`.
 
 ```js
 {

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The rule accepts the following configuration properties:
 - `groups`: May optionally be used to created customized named groups of members so that `order` can be more easily maintained. Groups can be referenced by name by using square brackets. E.g., `"[group-name]"`.
 - `accessorPairPositioning`: Used to specify the required positioning of get/set pairs. Available values: `getThenSet`, `setThenGet`, `together`, `any`.
 - `stopAfterFirstProblem`: Only report the first sort problem in each class (plus the number of problems found). Useful if you only want to know that the class has sort problems without spamming error messages. The default is `false`.
-- `locale`: Used to specify the second argument of class member names comparsion function [localeCompare](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare#using_locales). The default is `en-US`.
+- `locale`: Used to specify the locale settings for the name comparsion method. [Language tags](https://www.techonthenet.com/js/language_tags.php). The default is `en-US`.
 
 ```js
 {

--- a/src/rules/schema.js
+++ b/src/rules/schema.js
@@ -16,6 +16,9 @@ export const sortClassMembersSchema = [
 			accessorPairPositioning: {
 				enum: ['getThenSet', 'setThenGet', 'together', 'any'],
 			},
+			locale: {
+				type: 'string',
+			},
 		},
 		definitions: {
 			order: {

--- a/src/rules/sort-class-members.js
+++ b/src/rules/sort-class-members.js
@@ -236,9 +236,10 @@ function findAccessorPairProblems(members, positioning) {
 
 function findProblems(members, locale) {
 	const problems = [];
+	const collator = new Intl.Collator(locale);
 
 	forEachPair(members, (first, second) => {
-		if (!areMembersInCorrectOrder(first, second, locale)) {
+		if (!areMembersInCorrectOrder(first, second, collator)) {
 			problems.push({ source: second, target: first, expected: 'before' });
 		}
 	});
@@ -254,11 +255,11 @@ function forEachPair(list, callback) {
 	});
 }
 
-function areMembersInCorrectOrder(first, second, locale) {
+function areMembersInCorrectOrder(first, second, collator) {
 	return first.acceptableSlots.some(a =>
 		second.acceptableSlots.some(b =>
 			a.index === b.index && areSlotsAlphabeticallySorted(a, b)
-				? first.name.localeCompare(second.name, locale) <= 0
+				? collator.compare(first.name, second.name) <= 0
 				: a.index <= b.index
 		)
 	);

--- a/src/rules/sort-class-members.js
+++ b/src/rules/sort-class-members.js
@@ -10,6 +10,7 @@ export const sortClassMembers = {
 			const groups = { ...builtInGroups, ...defaults.groups, ...options.groups };
 			const orderedSlots = getExpectedOrder(order, groups);
 			const groupAccessors = accessorPairPositioning !== 'any';
+			const locale = options.locale || 'en-US';
 
 			const rules = {
 				ClassDeclaration(node) {
@@ -35,7 +36,7 @@ export const sortClassMembers = {
 					members = members.filter(member => member.acceptableSlots.length);
 
 					// check member positions against rule order
-					const problems = findProblems(members);
+					const problems = findProblems(members, locale);
 					const problemCount = problems.length;
 					for (const problem of problems) {
 						const message = 'Expected {{ source }} to come {{ expected }} {{ target }}.';
@@ -233,11 +234,11 @@ function findAccessorPairProblems(members, positioning) {
 	return problems;
 }
 
-function findProblems(members) {
+function findProblems(members, locale) {
 	const problems = [];
 
 	forEachPair(members, (first, second) => {
-		if (!areMembersInCorrectOrder(first, second)) {
+		if (!areMembersInCorrectOrder(first, second, locale)) {
 			problems.push({ source: second, target: first, expected: 'before' });
 		}
 	});
@@ -253,11 +254,11 @@ function forEachPair(list, callback) {
 	});
 }
 
-function areMembersInCorrectOrder(first, second) {
+function areMembersInCorrectOrder(first, second, locale) {
 	return first.acceptableSlots.some(a =>
 		second.acceptableSlots.some(b =>
 			a.index === b.index && areSlotsAlphabeticallySorted(a, b)
-				? first.name.localeCompare(second.name) <= 0
+				? first.name.localeCompare(second.name, locale) <= 0
 				: a.index <= b.index
 		)
 	);

--- a/test/rules/sort-class-members.spec.js
+++ b/test/rules/sort-class-members.spec.js
@@ -53,6 +53,36 @@ const alphabeticalOptions = [
 	},
 ];
 
+const alphabeticalLocaleENOptions = [
+	{
+		order: ['[constructor]', '[methods]'],
+		groups: {
+			methods: [
+				{
+					sort: 'alphabetical',
+					type: 'method',
+				},
+			],
+		},
+		locale: 'en-US'
+	},
+];
+
+const alphabeticalLocaleCSOptions = [
+	{
+		order: ['[constructor]', '[methods]'],
+		groups: {
+			methods: [
+				{
+					sort: 'alphabetical',
+					type: 'method',
+				},
+			],
+		},
+		locale: 'cs-CZ'
+	},
+];
+
 const objectOrderOptions = [
 	{
 		order: [
@@ -236,6 +266,14 @@ ruleTester.run('sort-class-members', rule, {
 		{
 			code: 'class A { constructor(){} a(){} b(){} c(){} }',
 			options: alphabeticalOptions,
+		},
+		{
+			code: 'class A { constructor(){} c(){} ch(){} h(){} }',
+			options: alphabeticalLocaleENOptions,
+		},
+		{
+			code: 'class A { constructor(){} c(){} h(){} ch(){} }',
+			options: alphabeticalLocaleCSOptions,
 		},
 
 		// Class expressions
@@ -452,6 +490,28 @@ ruleTester.run('sort-class-members', rule, {
 				},
 			],
 			options: alphabeticalOptions,
+		},
+		{
+			code: 'class A { constructor(){} h(){} ch(){} i(){} }',
+			output: 'class A { constructor(){} ch(){} h(){}  i(){} }',
+			errors: [
+				{
+					message: 'Expected method ch to come before method h.',
+					type: 'MethodDefinition',
+				},
+			],
+			options: alphabeticalLocaleENOptions,
+		},
+		{
+			code: 'class A { constructor(){} ch(){} h(){} i(){} }',
+			output: 'class A { constructor(){} h(){} ch(){}  i(){} }',
+			errors: [
+				{
+					message: 'Expected method h to come before method ch.',
+					type: 'MethodDefinition',
+				},
+			],
+			options: alphabeticalLocaleCSOptions,
 		},
 
 		// Class expressions

--- a/test/rules/sort-class-members.spec.js
+++ b/test/rules/sort-class-members.spec.js
@@ -64,22 +64,7 @@ const alphabeticalLocaleENOptions = [
 				},
 			],
 		},
-		locale: 'en-US'
-	},
-];
-
-const alphabeticalLocaleCSOptions = [
-	{
-		order: ['[constructor]', '[methods]'],
-		groups: {
-			methods: [
-				{
-					sort: 'alphabetical',
-					type: 'method',
-				},
-			],
-		},
-		locale: 'cs-CZ'
+		locale: 'en-US',
 	},
 ];
 
@@ -270,10 +255,6 @@ ruleTester.run('sort-class-members', rule, {
 		{
 			code: 'class A { constructor(){} c(){} ch(){} h(){} }',
 			options: alphabeticalLocaleENOptions,
-		},
-		{
-			code: 'class A { constructor(){} c(){} h(){} ch(){} }',
-			options: alphabeticalLocaleCSOptions,
 		},
 
 		// Class expressions
@@ -501,17 +482,6 @@ ruleTester.run('sort-class-members', rule, {
 				},
 			],
 			options: alphabeticalLocaleENOptions,
-		},
-		{
-			code: 'class A { constructor(){} ch(){} h(){} i(){} }',
-			output: 'class A { constructor(){} h(){} ch(){}  i(){} }',
-			errors: [
-				{
-					message: 'Expected method h to come before method ch.',
-					type: 'MethodDefinition',
-				},
-			],
-			options: alphabeticalLocaleCSOptions,
 		},
 
 		// Class expressions


### PR DESCRIPTION
* feat(options): add support for localeCompare locale argument

Add option to use as argument 'locale' while using string comparation, this solves case when CI/CD or another platform with different local settings provides different sort order than local run.

refactor: 💡 change compare method to Intl.Collator

Provided method has [better platform support and has much better performance](https://javascript.plainenglish.io/js-i18n-5-essential-tips-for-localecompare-intl-collator-27b8570196cd) than localeCompare