### PR TITLE
feat: add support for computed method keys

### DIFF
--- a/src/rules/sort-class-members.js
+++ b/src/rules/sort-class-members.js
@@ -187,7 +187,13 @@ function getMemberInfo(node, sourceCode) {
 				)) ||
 			[];
 	} else {
-		name = node.key.name;
+		if (node.computed) {
+			const keyBeforeToken = sourceCode.getTokenBefore(node.key);
+			const keyAfterToken = sourceCode.getTokenAfter(node.key);
+			name = sourceCode.getText().slice(keyBeforeToken.range[0], keyAfterToken.range[1]);
+		} else {
+			name = sourceCode.getText(node.key);
+		}
 		type = 'method';
 		async = node.value && node.value.async;
 	}

--- a/src/rules/sort-class-members.js
+++ b/src/rules/sort-class-members.js
@@ -192,7 +192,7 @@ function getMemberInfo(node, sourceCode) {
 			const keyAfterToken = sourceCode.getTokenAfter(node.key);
 			name = sourceCode.getText().slice(keyBeforeToken.range[0], keyAfterToken.range[1]);
 		} else {
-			name = sourceCode.getText(node.key);
+			name = node.key.name;
 		}
 		type = 'method';
 		async = node.value && node.value.async;

--- a/test/rules/sort-class-members.spec.js
+++ b/test/rules/sort-class-members.spec.js
@@ -116,6 +116,21 @@ const decoratorOptionsAlphabetical = [
 	},
 ];
 
+const computedMethodKeysCustomGroupOptions = [
+	{
+		order: ['constructor', '[computed-key-methods]'],
+		groups: {
+			'computed-key-methods': [
+				{
+					type: 'method',
+					name: '/^\\[[^\\]]+\\]$/',
+					sort: 'alphabetical',
+				},
+			],
+		},
+	},
+];
+
 ruleTester.run('sort-class-members', rule, {
 	valid: [
 		{ code: 'class A {}', options: defaultOptions },
@@ -625,6 +640,42 @@ ruleTester.run('sort-class-members', rule, {
 				},
 			],
 			options: objectOrderOptions,
+		},
+		// computed method keys
+		{
+			code:
+				'module.exports.foo = Symbol("bar"); class A { [ module.exports.foo ]() {} constructor() {} }',
+			output:
+				'module.exports.foo = Symbol("bar"); class A { constructor() {} [ module.exports.foo ]() {}  }',
+			errors: [
+				{
+					message: 'Expected constructor to come before method [ module.exports.foo ].',
+					type: 'MethodDefinition',
+				},
+			],
+			options: computedMethodKeysCustomGroupOptions,
+		},
+		{
+			code: 'var foo = "bar"; class A { [`${foo} baz`]() {} constructor() {} }',
+			output: 'var foo = "bar"; class A { constructor() {} [`${foo} baz`]() {}  }',
+			errors: [
+				{
+					message: 'Expected constructor to come before method [`${foo} baz`].',
+					type: 'MethodDefinition',
+				},
+			],
+			options: computedMethodKeysCustomGroupOptions,
+		},
+		{
+			code: 'var foo = () => "bar"; class A { [foo()]() {} constructor() {} }',
+			output: 'var foo = () => "bar"; class A { constructor() {} [foo()]() {}  }',
+			errors: [
+				{
+					message: 'Expected constructor to come before method [foo()].',
+					type: 'MethodDefinition',
+				},
+			],
+			options: computedMethodKeysCustomGroupOptions,
 		},
 	],
 });


### PR DESCRIPTION
Effectively #59 with support for more expressions.

It preserves brackets so the method keys can be distinguished from normal non-computed keys.