### PR TITLE
Private members support

### DIFF
--- a/src/rules/sort-class-members.js
+++ b/src/rules/sort-class-members.js
@@ -185,10 +185,10 @@ function getMemberInfo(node, sourceCode) {
 		const [first, second] = sourceCode.getFirstTokens(node.key, 2);
 
 		if (node.key.type === 'PrivateName') {
-      name = `#${node.key.id.name}`;
-    } else {
-      name = second && second.type === 'Identifier' ? second.value : first.value;
-    }
+			name = `#${node.key.id.name}`;
+		} else {
+			name = second && second.type === 'Identifier' ? second.value : first.value;
+		}
 
 		propertyType = node.value ? node.value.type : node.value;
 		decorators =
@@ -203,11 +203,11 @@ function getMemberInfo(node, sourceCode) {
 			const keyAfterToken = sourceCode.getTokenAfter(node.key);
 			name = sourceCode.getText().slice(keyBeforeToken.range[0], keyAfterToken.range[1]);
 		} else {
-      if (node.key.type === 'PrivateName') {
-        name = `#${node.key.id.name}`;
-      } else {
-        name = node.key.name;
-      }
+			if (node.key.type === 'PrivateName') {
+				name = `#${node.key.id.name}`;
+			} else {
+				name = node.key.name;
+			}
 		}
 		type = 'method';
 		async = node.value && node.value.async;

--- a/src/rules/sort-class-members.js
+++ b/src/rules/sort-class-members.js
@@ -180,10 +180,16 @@ function getMemberInfo(node, sourceCode) {
 	let async = false;
 	let decorators = [];
 
-	if (node.type === 'ClassProperty') {
+	if (node.type === 'ClassProperty' || node.type === 'ClassPrivateProperty') {
 		type = 'property';
 		const [first, second] = sourceCode.getFirstTokens(node.key, 2);
-		name = second && second.type === 'Identifier' ? second.value : first.value;
+
+		if (node.key.type === 'PrivateName') {
+      name = `#${node.key.id.name}`;
+    } else {
+      name = second && second.type === 'Identifier' ? second.value : first.value;
+    }
+
 		propertyType = node.value ? node.value.type : node.value;
 		decorators =
 			(!!node.decorators &&
@@ -197,7 +203,11 @@ function getMemberInfo(node, sourceCode) {
 			const keyAfterToken = sourceCode.getTokenAfter(node.key);
 			name = sourceCode.getText().slice(keyBeforeToken.range[0], keyAfterToken.range[1]);
 		} else {
-			name = node.key.name;
+      if (node.key.type === 'PrivateName') {
+        name = `#${node.key.id.name}`;
+      } else {
+        name = node.key.name;
+      }
 		}
 		type = 'method';
 		async = node.value && node.value.async;

--- a/test/rules/sort-class-members.spec.js
+++ b/test/rules/sort-class-members.spec.js
@@ -158,6 +158,62 @@ const computedMethodKeysCustomGroupOptions = [
 	},
 ];
 
+const privateAlphabeticalProperties = [{
+	groups: {
+		"private-properties": [{
+			"sort": "alphabetical",
+			"static": false,
+			"type": "property",
+			"name": "/#.+/"
+		}],
+	},
+	order: [
+		'[private-properties]'
+	],
+}];
+
+const privateStaticAlphabeticalProperties = [{
+	groups: {
+		"private-static-properties": [{
+			"sort": "alphabetical",
+			"static": true,
+			"type": "property",
+			"name": "/#.+/"
+		}],
+	},
+	order: [
+		'[private-static-properties]'
+	],
+}];
+
+const privateStaticAlphabeticalMethods = [{
+	groups: {
+		"private-static-methods": [{
+			"sort": "alphabetical",
+			"static": true,
+			"type": "method",
+			"name": "/#.+/"
+		}],
+	},
+	order: [
+		'[private-static-methods]'
+	],
+}];
+
+const privateAlphabeticalMethods = [{
+	groups: {
+		"private-methods": [{
+			"sort": "alphabetical",
+			"static": false,
+			"type": "method",
+			"name": "/#.+/"
+		}],
+	},
+	order: [
+		'[private-methods]'
+	],
+}];
+
 ruleTester.run('sort-class-members', rule, {
 	valid: [
 		{ code: 'class A {}', options: defaultOptions },
@@ -739,6 +795,59 @@ ruleTester.run('sort-class-members', rule, {
 				},
 			],
 			options: computedMethodKeysCustomGroupOptions,
+		},
+		// private members
+		{
+			code: 'class A { static #foo = 1; static #bar = 2; }',
+			output: 'class A { static #bar = 2; static #foo = 1;  }',
+			errors: [
+				{
+					message: 'Expected static property #bar to come before static property #foo.',
+					type: 'ClassPrivateProperty',
+				},
+			],
+			options: privateStaticAlphabeticalProperties,
+			parser: require.resolve('@babel/eslint-parser'),
+			parserOptions,
+		},
+		{
+			code: 'class A { #foo = 1; #bar = 2; }',
+			output: 'class A { #bar = 2; #foo = 1;  }',
+			errors: [
+				{
+					message: 'Expected property #bar to come before property #foo.',
+					type: 'ClassPrivateProperty',
+				},
+			],
+			options: privateAlphabeticalProperties,
+			parser: require.resolve('@babel/eslint-parser'),
+			parserOptions,
+		},
+		{
+			code: 'class A { static #foo() {} static #bar() {} }',
+			output: 'class A { static #bar() {} static #foo() {}  }',
+			errors: [
+				{
+					message: 'Expected static method #bar to come before static method #foo.',
+					type: 'MethodDefinition',
+				},
+			],
+			options: privateStaticAlphabeticalMethods,
+			parser: require.resolve('@babel/eslint-parser'),
+			parserOptions,
+		},
+		{
+			code: 'class A { #foo() {} #bar() {} }',
+			output: 'class A { #bar() {} #foo() {}  }',
+			errors: [
+				{
+					message: 'Expected method #bar to come before method #foo.',
+					type: 'MethodDefinition',
+				},
+			],
+			options: privateAlphabeticalMethods,
+			parser: require.resolve('@babel/eslint-parser'),
+			parserOptions,
 		},
 	],
 });

--- a/test/rules/sort-class-members.spec.js
+++ b/test/rules/sort-class-members.spec.js
@@ -158,61 +158,69 @@ const computedMethodKeysCustomGroupOptions = [
 	},
 ];
 
-const privateAlphabeticalProperties = [{
-	groups: {
-		"private-properties": [{
-			"sort": "alphabetical",
-			"static": false,
-			"type": "property",
-			"name": "/#.+/"
-		}],
+const privateAlphabeticalProperties = [
+	{
+		groups: {
+			'private-properties': [
+				{
+					sort: 'alphabetical',
+					static: false,
+					type: 'property',
+					name: '/#.+/',
+				},
+			],
+		},
+		order: ['[private-properties]'],
 	},
-	order: [
-		'[private-properties]'
-	],
-}];
+];
 
-const privateStaticAlphabeticalProperties = [{
-	groups: {
-		"private-static-properties": [{
-			"sort": "alphabetical",
-			"static": true,
-			"type": "property",
-			"name": "/#.+/"
-		}],
+const privateStaticAlphabeticalProperties = [
+	{
+		groups: {
+			'private-static-properties': [
+				{
+					sort: 'alphabetical',
+					static: true,
+					type: 'property',
+					name: '/#.+/',
+				},
+			],
+		},
+		order: ['[private-static-properties]'],
 	},
-	order: [
-		'[private-static-properties]'
-	],
-}];
+];
 
-const privateStaticAlphabeticalMethods = [{
-	groups: {
-		"private-static-methods": [{
-			"sort": "alphabetical",
-			"static": true,
-			"type": "method",
-			"name": "/#.+/"
-		}],
+const privateStaticAlphabeticalMethods = [
+	{
+		groups: {
+			'private-static-methods': [
+				{
+					sort: 'alphabetical',
+					static: true,
+					type: 'method',
+					name: '/#.+/',
+				},
+			],
+		},
+		order: ['[private-static-methods]'],
 	},
-	order: [
-		'[private-static-methods]'
-	],
-}];
+];
 
-const privateAlphabeticalMethods = [{
-	groups: {
-		"private-methods": [{
-			"sort": "alphabetical",
-			"static": false,
-			"type": "method",
-			"name": "/#.+/"
-		}],
+const privateAlphabeticalMethods = [
+	{
+		groups: {
+			'private-methods': [
+				{
+					sort: 'alphabetical',
+					static: false,
+					type: 'method',
+					name: '/#.+/',
+				},
+			],
+		},
+		order: ['[private-methods]'],
 	},
-	order: [
-		'[private-methods]'
-	],
-}];
+];
 
 ruleTester.run('sort-class-members', rule, {
 	valid: [


### PR DESCRIPTION
Another attempt to add support for [JavaScript private members](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields). Basically, it just adds a hash `#` to the name of private members so we can define custom rules for any kind of private members (anything that is prefixed with `#`).