### PR TITLE
Add private property to group rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Members can be matched to positional slots using several criteria, including nam
 - `propertyType`: A subtype of `type: "property"` that can match the type of the property value. e.g., `propertyType: "ArrowFunctionExpression"` to match properties whose value is initialized to an arrow function.
 - `accessorPair`: `true|false`. True to match only getters and setters that are part of a pair. i.e., only those that have both `get` and `set` methods defined.
 - `static`: `true|false` to restrict the match to static or instance members.
+- `private`: `true|false` to restrict the match to [private members](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields). **Note**: Private members currently require a custom parser like [babel-eslint](https://github.com/babel/babel-eslint).
 - `async`: `true|false` to restrict the match to async members.
 - `sort`: `"alphabetical"|"none"`. Used to require a specific sorting within the slot for matched members. Defaults to `"none"`.
 - `groupByDecorator`: a string used to group properties with the same decorator name (e.g. `observable` for `@observable`). Can be used together with `sort`. **Note**: Decorators are a Stage 2 proposal and require a custom parser like [babel-eslint](https://github.com/babel/babel-eslint).
@@ -112,6 +113,7 @@ A few examples:
 
 - `{ "name": "create", "type": "method", "static": true }` would match a static method named `create`.
 - `{ "static": true }` would match all static methods and properties.
+- `{ "type": "method", "private": true }` would match all private methods.
 - `{ "async": true }` would match all async methods.
 - `{ "name": "/on.+/", "type": "method" }` would match both static and instance methods whose names start with "on".
 - `"/on.+/"` is shorthand for `{ "name": "/on.+/" }`, and would match all static and instance methods and properties whose names start with "on".

--- a/src/rules/schema.js
+++ b/src/rules/schema.js
@@ -37,6 +37,7 @@ export const sortClassMembersSchema = [
 								accessorPair: { type: 'boolean' },
 								sort: { enum: ['alphabetical', 'none'] },
 								static: { type: 'boolean' },
+								private: { type: 'boolean' },
 								async: { type: 'boolean' },
 							},
 							additionalProperties: false,

--- a/src/rules/sort-class-members.js
+++ b/src/rules/sort-class-members.js
@@ -185,10 +185,10 @@ function getMemberInfo(node, sourceCode) {
 		const [first, second] = sourceCode.getFirstTokens(node.key, 2);
 
 		if (node.key.type === 'PrivateName') {
-      name = `#${node.key.id.name}`;
-    } else {
-      name = second && second.type === 'Identifier' ? second.value : first.value;
-    }
+			name = `#${node.key.id.name}`;
+		} else {
+			name = second && second.type === 'Identifier' ? second.value : first.value;
+		}
 
 		propertyType = node.value ? node.value.type : node.value;
 		decorators =
@@ -203,11 +203,11 @@ function getMemberInfo(node, sourceCode) {
 			const keyAfterToken = sourceCode.getTokenAfter(node.key);
 			name = sourceCode.getText().slice(keyBeforeToken.range[0], keyAfterToken.range[1]);
 		} else {
-      if (node.key.type === 'PrivateName') {
-        name = `#${node.key.id.name}`;
-      } else {
-        name = node.key.name;
-      }
+			if (node.key.type === 'PrivateName') {
+				name = `#${node.key.id.name}`;
+			} else {
+				name = node.key.name;
+			}
 		}
 		type = 'method';
 		async = node.value && node.value.async;

--- a/src/rules/sort-class-members.js
+++ b/src/rules/sort-class-members.js
@@ -180,10 +180,16 @@ function getMemberInfo(node, sourceCode) {
 	let async = false;
 	let decorators = [];
 
-	if (node.type === 'ClassProperty') {
+	if (node.type === 'ClassProperty' || node.type === 'ClassPrivateProperty') {
 		type = 'property';
 		const [first, second] = sourceCode.getFirstTokens(node.key, 2);
-		name = second && second.type === 'Identifier' ? second.value : first.value;
+
+		if (node.key.type === 'PrivateName') {
+      name = `#${node.key.id.name}`;
+    } else {
+      name = second && second.type === 'Identifier' ? second.value : first.value;
+    }
+
 		propertyType = node.value ? node.value.type : node.value;
 		decorators =
 			(!!node.decorators &&
@@ -197,7 +203,11 @@ function getMemberInfo(node, sourceCode) {
 			const keyAfterToken = sourceCode.getTokenAfter(node.key);
 			name = sourceCode.getText().slice(keyBeforeToken.range[0], keyAfterToken.range[1]);
 		} else {
-			name = node.key.name;
+      if (node.key.type === 'PrivateName') {
+        name = `#${node.key.id.name}`;
+      } else {
+        name = node.key.name;
+      }
 		}
 		type = 'method';
 		async = node.value && node.value.async;

--- a/src/rules/sort-class-members.js
+++ b/src/rules/sort-class-members.js
@@ -174,6 +174,7 @@ function getClassMemberInfos(classDeclaration, sourceCode, orderedSlots) {
 }
 
 function getMemberInfo(node, sourceCode) {
+	const priv = node.key.type === 'PrivateName';
 	let name;
 	let type;
 	let propertyType;
@@ -182,11 +183,11 @@ function getMemberInfo(node, sourceCode) {
 
 	if (node.type === 'ClassProperty' || node.type === 'ClassPrivateProperty') {
 		type = 'property';
-		const [first, second] = sourceCode.getFirstTokens(node.key, 2);
 
-		if (node.key.type === 'PrivateName') {
+		if (priv) {
 			name = `#${node.key.id.name}`;
 		} else {
+			const [first, second] = sourceCode.getFirstTokens(node.key, 2);
 			name = second && second.type === 'Identifier' ? second.value : first.value;
 		}
 
@@ -203,11 +204,7 @@ function getMemberInfo(node, sourceCode) {
 			const keyAfterToken = sourceCode.getTokenAfter(node.key);
 			name = sourceCode.getText().slice(keyBeforeToken.range[0], keyAfterToken.range[1]);
 		} else {
-			if (node.key.type === 'PrivateName') {
-				name = `#${node.key.id.name}`;
-			} else {
-				name = node.key.name;
-			}
+			name = priv ? `#${node.key.id.name}` : node.key.name;
 		}
 		type = 'method';
 		async = node.value && node.value.async;
@@ -219,6 +216,7 @@ function getMemberInfo(node, sourceCode) {
 		decorators,
 		static: node.static,
 		async,
+		private: priv,
 		kind: node.kind,
 		propertyType,
 		node,
@@ -418,6 +416,7 @@ const comparers = [
 	{ property: 'type', value: 10, test: (m, s) => s.type === m.type },
 	{ property: 'static', value: 10, test: (m, s) => s.static === m.static },
 	{ property: 'async', value: 10, test: (m, s) => s.async === m.async },
+	{ property: 'private', value: 10, test: (m, s) => s.private === m.private },
 	{ property: 'kind', value: 10, test: (m, s) => s.kind === m.kind },
 	{
 		property: 'groupByDecorator',

--- a/test/rules/sort-class-members.spec.js
+++ b/test/rules/sort-class-members.spec.js
@@ -158,6 +158,62 @@ const computedMethodKeysCustomGroupOptions = [
 	},
 ];
 
+const privateAlphabeticalProperties = [{
+	groups: {
+		"private-properties": [{
+			"sort": "alphabetical",
+			"static": false,
+			"type": "property",
+			"name": "/#.+/"
+		}],
+	},
+	order: [
+		'[private-properties]'
+	],
+}];
+
+const privateStaticAlphabeticalProperties = [{
+	groups: {
+		"private-static-properties": [{
+			"sort": "alphabetical",
+			"static": true,
+			"type": "property",
+			"name": "/#.+/"
+		}],
+	},
+	order: [
+		'[private-static-properties]'
+	],
+}];
+
+const privateStaticAlphabeticalMethods = [{
+	groups: {
+		"private-static-methods": [{
+			"sort": "alphabetical",
+			"static": true,
+			"type": "method",
+			"name": "/#.+/"
+		}],
+	},
+	order: [
+		'[private-static-methods]'
+	],
+}];
+
+const privateAlphabeticalMethods = [{
+	groups: {
+		"private-methods": [{
+			"sort": "alphabetical",
+			"static": false,
+			"type": "method",
+			"name": "/#.+/"
+		}],
+	},
+	order: [
+		'[private-methods]'
+	],
+}];
+
 ruleTester.run('sort-class-members', rule, {
 	valid: [
 		{ code: 'class A {}', options: defaultOptions },
@@ -739,6 +795,59 @@ ruleTester.run('sort-class-members', rule, {
 				},
 			],
 			options: computedMethodKeysCustomGroupOptions,
+		},
+		// private members
+		{
+			code: 'class A { static #foo = 1; static #bar = 2; }',
+			output: 'class A { static #bar = 2; static #foo = 1;  }',
+			errors: [
+				{
+					message: 'Expected static property #bar to come before static property #foo.',
+					type: 'ClassPrivateProperty',
+				},
+			],
+			options: privateStaticAlphabeticalProperties,
+			parser: require.resolve('@babel/eslint-parser'),
+			parserOptions,
+		},
+		{
+			code: 'class A { #foo = 1; #bar = 2; }',
+			output: 'class A { #bar = 2; #foo = 1;  }',
+			errors: [
+				{
+					message: 'Expected property #bar to come before property #foo.',
+					type: 'ClassPrivateProperty',
+				},
+			],
+			options: privateAlphabeticalProperties,
+			parser: require.resolve('@babel/eslint-parser'),
+			parserOptions,
+		},
+		{
+			code: 'class A { static #foo() {} static #bar() {} }',
+			output: 'class A { static #bar() {} static #foo() {}  }',
+			errors: [
+				{
+					message: 'Expected static method #bar to come before static method #foo.',
+					type: 'MethodDefinition',
+				},
+			],
+			options: privateStaticAlphabeticalMethods,
+			parser: require.resolve('@babel/eslint-parser'),
+			parserOptions,
+		},
+		{
+			code: 'class A { #foo() {} #bar() {} }',
+			output: 'class A { #bar() {} #foo() {}  }',
+			errors: [
+				{
+					message: 'Expected method #bar to come before method #foo.',
+					type: 'MethodDefinition',
+				},
+			],
+			options: privateAlphabeticalMethods,
+			parser: require.resolve('@babel/eslint-parser'),
+			parserOptions,
 		},
 	],
 });

--- a/test/rules/sort-class-members.spec.js
+++ b/test/rules/sort-class-members.spec.js
@@ -158,61 +158,69 @@ const computedMethodKeysCustomGroupOptions = [
 	},
 ];
 
-const privateAlphabeticalProperties = [{
-	groups: {
-		"private-properties": [{
-			"sort": "alphabetical",
-			"static": false,
-			"type": "property",
-			"name": "/#.+/"
-		}],
+const privateAlphabeticalProperties = [
+	{
+		groups: {
+			'private-properties': [
+				{
+					sort: 'alphabetical',
+					static: false,
+					type: 'property',
+					name: '/#.+/',
+				},
+			],
+		},
+		order: ['[private-properties]'],
 	},
-	order: [
-		'[private-properties]'
-	],
-}];
+];
 
-const privateStaticAlphabeticalProperties = [{
-	groups: {
-		"private-static-properties": [{
-			"sort": "alphabetical",
-			"static": true,
-			"type": "property",
-			"name": "/#.+/"
-		}],
+const privateStaticAlphabeticalProperties = [
+	{
+		groups: {
+			'private-static-properties': [
+				{
+					sort: 'alphabetical',
+					static: true,
+					type: 'property',
+					name: '/#.+/',
+				},
+			],
+		},
+		order: ['[private-static-properties]'],
 	},
-	order: [
-		'[private-static-properties]'
-	],
-}];
+];
 
-const privateStaticAlphabeticalMethods = [{
-	groups: {
-		"private-static-methods": [{
-			"sort": "alphabetical",
-			"static": true,
-			"type": "method",
-			"name": "/#.+/"
-		}],
+const privateStaticAlphabeticalMethods = [
+	{
+		groups: {
+			'private-static-methods': [
+				{
+					sort: 'alphabetical',
+					static: true,
+					type: 'method',
+					name: '/#.+/',
+				},
+			],
+		},
+		order: ['[private-static-methods]'],
 	},
-	order: [
-		'[private-static-methods]'
-	],
-}];
+];
 
-const privateAlphabeticalMethods = [{
-	groups: {
-		"private-methods": [{
-			"sort": "alphabetical",
-			"static": false,
-			"type": "method",
-			"name": "/#.+/"
-		}],
+const privateAlphabeticalMethods = [
+	{
+		groups: {
+			'private-methods': [
+				{
+					sort: 'alphabetical',
+					static: false,
+					type: 'method',
+					name: '/#.+/',
+				},
+			],
+		},
+		order: ['[private-methods]'],
 	},
-	order: [
-		'[private-methods]'
-	],
-}];
+];
 
 ruleTester.run('sort-class-members', rule, {
 	valid: [

--- a/test/rules/sort-class-members.spec.js
+++ b/test/rules/sort-class-members.spec.js
@@ -166,7 +166,7 @@ const privateAlphabeticalProperties = [
 					sort: 'alphabetical',
 					static: false,
 					type: 'property',
-					name: '/#.+/',
+					private: true,
 				},
 			],
 		},
@@ -182,7 +182,7 @@ const privateStaticAlphabeticalProperties = [
 					sort: 'alphabetical',
 					static: true,
 					type: 'property',
-					name: '/#.+/',
+					private: true,
 				},
 			],
 		},
@@ -198,7 +198,7 @@ const privateStaticAlphabeticalMethods = [
 					sort: 'alphabetical',
 					static: true,
 					type: 'method',
-					name: '/#.+/',
+					private: true,
 				},
 			],
 		},
@@ -214,11 +214,17 @@ const privateAlphabeticalMethods = [
 					sort: 'alphabetical',
 					static: false,
 					type: 'method',
-					name: '/#.+/',
+					private: true,
 				},
 			],
 		},
 		order: ['[private-methods]'],
+	},
+];
+
+const privateRegexpOptions = [
+	{
+		order: ['before', '/#ab.+/', 'after', '[everything-else]'],
 	},
 ];
 
@@ -854,6 +860,19 @@ ruleTester.run('sort-class-members', rule, {
 				},
 			],
 			options: privateAlphabeticalMethods,
+			parser: require.resolve('@babel/eslint-parser'),
+			parserOptions,
+		},
+		{
+			code: 'class A { #abc(){} before(){} after(){} }',
+			output: 'class A { before(){} #abc(){}  after(){} }',
+			errors: [
+				{
+					message: 'Expected method before to come before method #abc.',
+					type: 'MethodDefinition',
+				},
+			],
+			options: privateRegexpOptions,
 			parser: require.resolve('@babel/eslint-parser'),
 			parserOptions,
 		},


### PR DESCRIPTION
Added a new property `private` to restrict matching to private members only without using a regular expression like `"name": "/#.+/"` (names of private members still start with `#` though). 
