### PR TITLE
fix: compatability with eslint pareser 5

### DIFF
--- a/src/rules/sort-class-members.js
+++ b/src/rules/sort-class-members.js
@@ -181,7 +181,12 @@ function getMemberInfo(node, sourceCode) {
 	let async = false;
 	let decorators = [];
 
-	if (node.type === 'ClassProperty' || node.type === 'ClassPrivateProperty') {
+	if (
+		node.type === 'ClassProperty' ||
+		node.type === 'ClassPrivateProperty' ||
+		node.type === 'PropertyDefinition' ||
+		node.type === 'PrivateIdentifier'
+	) {
 		type = 'property';
 
 		if (priv) {


### PR DESCRIPTION
Fixes #71 

Breaking changes were introduced [here](https://github.com/typescript-eslint/typescript-eslint/releases/tag/v5.0.0) under TypeScript-ESTree / AST-Spec