### PR TITLE
feat: support @babel/eslint-parser 7.16.0 (espree8) and above

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,13 @@ Install [ESLint](http://eslint.org) and `eslint-plugin-sort-class-members`:
 $ npm install eslint eslint-plugin-sort-class-members --save-dev
 ```
 
-**Note:** If you installed ESLint globally (using the `-g` flag) then you must also install `eslint-plugin-sort-class-members` globally.
+### Note
+
+- If you installed ESLint globally (using the `-g` flag) then you must also install `eslint-plugin-sort-class-members` globally.
+
+- `15.x` is only compatible with `@babel/eslint-parser@7.16.0` and above. Please install [`14.1`](https://github.com/bryanrsmith/eslint-plugin-sort-class-members/releases/tag/v1.14.1) or [`14.0`](https://github.com/bryanrsmith/eslint-plugin-sort-class-members/releases/tag/v1.14.0) if you are using `@babel/eslint-parser@7.15.8` or smaller.
+
+- This package may not work as expected with `@typescript-eslint/parser`, please file an issue if necessary.
 
 ## Usage
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -294,9 +294,9 @@
       }
     },
     "@babel/eslint-parser": {
-      "version": "7.15.8",
-      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.15.8.tgz",
-      "integrity": "sha512-fYP7QFngCvgxjUuw8O057SVH5jCXsbFFOoE77CFDcvzwBVgTOkMD/L4mIC5Ud1xf8chK/no2fRbSSn1wvNmKuQ==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.18.9.tgz",
+      "integrity": "sha512-KzSGpMBggz4fKbRbWLNyPVTuQr6cmCcBhOyXTw/fieOVaw5oYAwcAj4a7UKcDYCPxQq+CG1NCDZH9e2JTXquiQ==",
       "dev": true,
       "requires": {
         "eslint-scope": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "eslint-plugin-sort-class-members",
-	"version": "1.14.1",
+	"version": "1.15.0",
 	"description": "ESLint rule for enforcing consistent ES6 class member order.",
 	"keywords": [
 		"eslint",
@@ -38,7 +38,7 @@
 	},
 	"devDependencies": {
 		"@babel/cli": "^7.8.4",
-		"@babel/eslint-parser": "^7.15.8",
+		"@babel/eslint-parser": "^7.16.0",
 		"@babel/plugin-proposal-class-properties": "^7.14.5",
 		"@babel/plugin-proposal-decorators": "^7.15.8",
 		"@babel/preset-env": "^7.9.5",

--- a/src/rules/sort-class-members.js
+++ b/src/rules/sort-class-members.js
@@ -168,23 +168,18 @@ function getClassMemberInfos(classDeclaration, sourceCode, orderedSlots) {
 }
 
 function getMemberInfo(node, sourceCode) {
-	const priv = node.key.type === 'PrivateName';
+	const priv = node.key.type === 'PrivateIdentifier';
 	let name;
 	let type;
 	let propertyType;
 	let async = false;
 	let decorators = [];
 
-	if (
-		node.type === 'ClassProperty' ||
-		node.type === 'ClassPrivateProperty' ||
-		node.type === 'PropertyDefinition' ||
-		node.type === 'PrivateIdentifier'
-	) {
+	if (node.type === 'PropertyDefinition') {
 		type = 'property';
 
 		if (priv) {
-			name = `#${node.key.id.name}`;
+			name = `#${node.key.name}`;
 		} else {
 			const [first, second] = sourceCode.getFirstTokens(node.key, 2);
 			name = second && second.type === 'Identifier' ? second.value : first.value;
@@ -203,7 +198,7 @@ function getMemberInfo(node, sourceCode) {
 			const keyAfterToken = sourceCode.getTokenAfter(node.key);
 			name = sourceCode.getText().slice(keyBeforeToken.range[0], keyAfterToken.range[1]);
 		} else {
-			name = priv ? `#${node.key.id.name}` : node.key.name;
+			name = priv ? `#${node.key.name}` : node.key.name;
 		}
 		type = 'method';
 		async = node.value && node.value.async;

--- a/test/rules/sort-class-members.spec.js
+++ b/test/rules/sort-class-members.spec.js
@@ -391,7 +391,7 @@ ruleTester.run('sort-class-members', rule, {
 			errors: [
 				{
 					message: 'Expected property bar to come before constructor.',
-					type: 'ClassProperty',
+					type: 'PropertyDefinition',
 				},
 			],
 			parser: require.resolve('@babel/eslint-parser'),
@@ -404,7 +404,7 @@ ruleTester.run('sort-class-members', rule, {
 			errors: [
 				{
 					message: 'Expected static property bar to come before constructor.',
-					type: 'ClassProperty',
+					type: 'PropertyDefinition',
 				},
 			],
 			parser: require.resolve('@babel/eslint-parser'),
@@ -417,7 +417,7 @@ ruleTester.run('sort-class-members', rule, {
 			errors: [
 				{
 					message: 'Expected property foo to come before property bar.',
-					type: 'ClassProperty',
+					type: 'PropertyDefinition',
 				},
 			],
 			parser: require.resolve('@babel/eslint-parser'),
@@ -731,11 +731,11 @@ ruleTester.run('sort-class-members', rule, {
 			errors: [
 				{
 					message: 'Expected property foo to come before property baz.',
-					type: 'ClassProperty',
+					type: 'PropertyDefinition',
 				},
 				{
 					message: 'Expected property foo to come before property hoge.',
-					type: 'ClassProperty',
+					type: 'PropertyDefinition',
 				},
 			],
 			options: decoratorOptions,
@@ -748,7 +748,7 @@ ruleTester.run('sort-class-members', rule, {
 			errors: [
 				{
 					message: 'Expected property bar to come before property foo.',
-					type: 'ClassProperty',
+					type: 'PropertyDefinition',
 				},
 			],
 			options: decoratorOptionsAlphabetical,
@@ -811,7 +811,7 @@ ruleTester.run('sort-class-members', rule, {
 			errors: [
 				{
 					message: 'Expected static property #bar to come before static property #foo.',
-					type: 'ClassPrivateProperty',
+					type: 'PropertyDefinition',
 				},
 			],
 			options: privateStaticAlphabeticalProperties,
@@ -824,7 +824,7 @@ ruleTester.run('sort-class-members', rule, {
 			errors: [
 				{
 					message: 'Expected property #bar to come before property #foo.',
-					type: 'ClassPrivateProperty',
+					type: 'PropertyDefinition',
 				},
 			],
 			options: privateAlphabeticalProperties,


### PR DESCRIPTION
`@babel/eslint-parser` has some breaking change in private property between `7.16.0+` and `7.15.8` .

So the `private` condition need some modifications.

> I think this happens when `espree@7` upgrade to `espree@8`