### PR TITLE
fix: support decorators on method type

### DIFF
--- a/src/rules/sort-class-members.js
+++ b/src/rules/sort-class-members.js
@@ -175,6 +175,13 @@ function getMemberInfo(node, sourceCode) {
 	let async = false;
 	let decorators = [];
 
+	decorators =
+		(!!node.decorators &&
+			node.decorators.map((n) =>
+				n.expression.type === 'CallExpression' ? n.expression.callee.name : n.expression.name
+			)) ||
+		[];
+
 	if (
 		node.type === 'ClassProperty' ||
 		node.type === 'ClassPrivateProperty' ||
@@ -191,12 +198,6 @@ function getMemberInfo(node, sourceCode) {
 		}
 
 		propertyType = node.value ? node.value.type : node.value;
-		decorators =
-			(!!node.decorators &&
-				node.decorators.map((n) =>
-					n.expression.type === 'CallExpression' ? n.expression.callee.name : n.expression.name
-				)) ||
-			[];
 	} else {
 		if (node.computed) {
 			const keyBeforeToken = sourceCode.getTokenBefore(node.key);

--- a/test/rules/sort-class-members.spec.js
+++ b/test/rules/sort-class-members.spec.js
@@ -126,9 +126,10 @@ const propertyTypeOptions = [
 
 const decoratorOptions = [
 	{
-		order: ['[observables]', '[properties]', '[injects]'],
+		order: ['[observables]', '[properties]', '[actions]', '[injects]'],
 		groups: {
 			observables: [{ type: 'property', groupByDecorator: 'observable' }],
+			actions: [{ type: 'method', groupByDecorator: 'action' }],
 			injects: [{ type: 'property', groupByDecorator: 'Inject' }],
 		},
 	},
@@ -273,7 +274,7 @@ ruleTester.run('sort-class-members', rule, {
 
 		// class properties with decorators
 		{
-			code: 'class A { @observable bar = 2; @observable baz = 1; foo = 3; @Inject() hoge = 4; @observable @Inject() fuga = 5; constructor(){} }',
+			code: 'class A { @observable bar = 2; @observable baz = 1; foo = 3; @action lorem(){} @Inject() hoge = 4; @observable @Inject() fuga = 5; constructor(){} }',
 			options: decoratorOptions,
 			parser: require.resolve('@babel/eslint-parser'),
 			parserOptions,
@@ -725,9 +726,9 @@ ruleTester.run('sort-class-members', rule, {
 			parserOptions,
 		},
 		{
-			code: 'class A {  @observable bar = 2; baz = 3; @Inject() hoge = 4; @observable foo = 1; @observable @Inject() fuga = 5; constructor(){} }',
+			code: 'class A {  @observable bar = 2; baz = 3; @Inject() hoge = 4; @observable foo = 1; @observable @Inject() fuga = 5; @action lorem(){} constructor(){} }',
 			output:
-				'class A {  @observable bar = 2; @observable foo = 1; baz = 3; @Inject() hoge = 4;  @observable @Inject() fuga = 5; constructor(){} }',
+				'class A {  @observable bar = 2; @observable foo = 1; baz = 3; @Inject() hoge = 4;  @observable @Inject() fuga = 5; @action lorem(){} constructor(){} }',
 			errors: [
 				{
 					message: 'Expected property foo to come before property baz.',
@@ -736,6 +737,10 @@ ruleTester.run('sort-class-members', rule, {
 				{
 					message: 'Expected property foo to come before property hoge.',
 					type: 'ClassProperty',
+				},
+				{
+					message: 'Expected method lorem to come before property hoge.',
+					type: 'MethodDefinition',
 				},
 			],
 			options: decoratorOptions,


### PR DESCRIPTION
Created because of https://github.com/bryanrsmith/eslint-plugin-sort-class-members/issues/69

Previously, decorators only got taken into account for properties, but since it's also possible to add decorators to methods I've moved this logic outside of the if statement.

Thanks a lot for this package!