### PR TITLE
Add invalid abstract property test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eslint-plugin-sort-class-members",
-  "version": "1.16.0",
+  "version": "1.17.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "eslint-plugin-sort-class-members",
-      "version": "1.16.0",
+      "version": "1.17.1",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "^7.8.4",

--- a/test/rules/sort-class-members.spec.js
+++ b/test/rules/sort-class-members.spec.js
@@ -403,7 +403,7 @@ ruleTester.run('sort-class-members', rule, {
 			parser: require.resolve('@typescript-eslint/parser'),
 		},
 		{
-			code: 'abstract class Foo<T> { protected abstract readonly _foo: T; public readonly bar: string; protected constructor(bar: string) {}}',
+			code: 'abstract class Foo<T> { protected abstract readonly _foo: T; public readonly bar: string; protected constructor(bar: string) {} }',
 			options: [{ order: ['[properties]', 'constructor', '[methods]'] }],
 			parser: require.resolve('@typescript-eslint/parser'),
 		},
@@ -953,6 +953,18 @@ ruleTester.run('sort-class-members', rule, {
 				},
 			],
 			options: typescriptKeywordsOptions,
+			parser: require.resolve('@typescript-eslint/parser'),
+		},
+		{
+			code: 'abstract class Foo<T> { public readonly bar: string; protected constructor(bar: string) {} protected abstract readonly _foo: T; public abstract get data(): Foo<T>[\'_foo\']; protected abstract parse(baz?: string): T; protected abstract stringify(): string; }',
+			output: 'abstract class Foo<T> { public readonly bar: string; protected abstract readonly _foo: T; protected constructor(bar: string) {}  public abstract get data(): Foo<T>[\'_foo\']; protected abstract parse(baz?: string): T; protected abstract stringify(): string; }',
+			errors: [
+				{
+					message: 'Expected property _foo to come before constructor.',
+					type: 'TSAbstractPropertyDefinition',
+				},
+			],
+			options: [{ order: ['[properties]', 'constructor', '[methods]'] }],
 			parser: require.resolve('@typescript-eslint/parser'),
 		},
 	],


### PR DESCRIPTION
This pull request makes the following changes:
- Adds an invalid test for `TSAbstractPropertyDefinition` to coincide with the valid test added in 30bd9ef9fbc19fc07fc5d81e7dcc730cf83af8d2.
- Adds a missing space in the above-mentioned valid test from 30bd9ef9fbc19fc07fc5d81e7dcc730cf83af8d2.
- Updates the package version in `package-lock.json`. This was an automatic change from `npm` when I ran `npm install`. This most likely should have been done as part of the last release.

I ran `npm test` to confirm that this new test works as intended. Here is a snippet from running `npm test` to show it passes:
```
      √ class { abstract a(); readonly b; } (3 ms)
      √ abstract class Foo<T> { public readonly bar: string; protected constructor(bar: string) {} protected abstract readonly _foo: T; public abstract get data(): Foo<T>['_foo']; protected abstract parse(baz?: string): T; protected abstract stringify(): string; } (11 ms)
```