### PR TITLE
noDecorator option

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Members can be matched to positional slots using several criteria, including nam
 - `async`: `true|false` to restrict the match to async members.
 - `sort`: `"alphabetical"|"none"`. Used to require a specific sorting within the slot for matched members. Defaults to `"none"`.
 - `groupByDecorator`: a string used to group properties with the same decorator name (e.g. `observable` for `@observable`). Can be used together with `sort`. **Note**: Decorators are a Stage 2 proposal and require a custom parser like [babel-eslint](https://github.com/babel/babel-eslint).
+- `noDecorator`: `true|false` to restrict the match to members with no decorator. **Note**: Decorators are a Stage 2 proposal and require a custom parser like [babel-eslint](https://github.com/babel/babel-eslint).
 
 A few examples:
 

--- a/README.md
+++ b/README.md
@@ -110,8 +110,7 @@ Members can be matched to positional slots using several criteria, including nam
 - `readonly`: `true|false` to restrict the match to members with typescript `readonly` keyword.
 - `async`: `true|false` to restrict the match to async members.
 - `sort`: `"alphabetical"|"none"`. Used to require a specific sorting within the slot for matched members. Defaults to `"none"`.
-- `groupByDecorator`: a string used to group properties with the same decorator name (e.g. `observable` for `@observable`). Can be used together with `sort`. **Note**: Decorators are a Stage 2 proposal and require a custom parser like [babel-eslint](https://github.com/babel/babel-eslint).
-- `noDecorator`: `true|false` to restrict the match to members with no decorator. **Note**: Decorators are a Stage 2 proposal and require a custom parser like [babel-eslint](https://github.com/babel/babel-eslint).
+- `groupByDecorator`: `string|true|false`. A boolean used to indicate whether a property/method should have a decorator or a string used to group properties/methods with the same decorator name (e.g. `observable` for `@observable`). Can be used together with `sort`. **Note**: Decorators are a Stage 2 proposal and require a custom parser like [babel-eslint](https://github.com/babel/babel-eslint).
 
 A few examples:
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Members can be matched to positional slots using several criteria, including nam
 - `readonly`: `true|false` to restrict the match to members with typescript `readonly` keyword.
 - `async`: `true|false` to restrict the match to async members.
 - `sort`: `"alphabetical"|"none"`. Used to require a specific sorting within the slot for matched members. Defaults to `"none"`.
-- `groupByDecorator`: `string|true|false`. A boolean used to indicate whether a property/method should have a decorator or a string used to group properties/methods with the same decorator name (e.g. `observable` for `@observable`). Can be used together with `sort`. **Note**: Decorators are a Stage 2 proposal and require a custom parser like [babel-eslint](https://github.com/babel/babel-eslint).
+- `groupByDecorator`: `string|true|false`. A boolean used to indicate whether a property/method should have a decorator or a string used to group properties/methods with the same decorator name (e.g. `observable` for `@observable`). If the string starts and ends with `/` it will be interpreted as a regular expression. E.g., `"/_.+/"` will match members that have a decorator that starts with an underscore. Can be used together with `sort`. **Note**: Decorators are a Stage 2 proposal and require a custom parser like [babel-eslint](https://github.com/babel/babel-eslint).
 
 A few examples:
 

--- a/src/rules/schema.js
+++ b/src/rules/schema.js
@@ -31,6 +31,7 @@ export const sortClassMembersSchema = [
 							properties: {
 								name: { type: 'string' },
 								groupByDecorator: { type: 'string' },
+								noDecorator: { type: 'boolean' },
 								type: { enum: ['method', 'property'] },
 								kind: { enum: ['get', 'set'] },
 								propertyType: { type: 'string' },

--- a/src/rules/schema.js
+++ b/src/rules/schema.js
@@ -30,8 +30,7 @@ export const sortClassMembersSchema = [
 							type: 'object',
 							properties: {
 								name: { type: 'string' },
-								groupByDecorator: { type: 'string' },
-								noDecorator: { type: 'boolean' },
+								groupByDecorator: { oneOf: [{type: 'string'}, {type: 'boolean'}] },
 								type: { enum: ['method', 'property'] },
 								kind: { enum: ['get', 'set'] },
 								propertyType: { type: 'string' },

--- a/src/rules/schema.js
+++ b/src/rules/schema.js
@@ -30,7 +30,7 @@ export const sortClassMembersSchema = [
 							type: 'object',
 							properties: {
 								name: { type: 'string' },
-								groupByDecorator: { oneOf: [{type: 'string'}, {type: 'boolean'}] },
+								groupByDecorator: { oneOf: [{ type: 'string' }, { type: 'boolean' }] },
 								type: { enum: ['method', 'property'] },
 								kind: { enum: ['get', 'set', 'accessor', 'nonAccessor'] },
 								propertyType: { type: 'string' },

--- a/src/rules/sort-class-members.js
+++ b/src/rules/sort-class-members.js
@@ -441,7 +441,8 @@ const comparers = [
 				const hasDecorators = m.decorators.length > 0
 				return (s.groupByDecorator && hasDecorators) || (!s.groupByDecorator && !hasDecorators)
 			} else {
-				return m.decorators.includes(s.groupByDecorator)
+				const comparer = getStringComparer(s.groupByDecorator);
+				return m.decorators.some((decorator) => comparer(decorator));
 			}
 		},
 	},

--- a/src/rules/sort-class-members.js
+++ b/src/rules/sort-class-members.js
@@ -451,7 +451,7 @@ const comparers = [
 		test: (m, s) => {
 			if (typeof s.groupByDecorator === 'boolean') {
 				const hasDecorators = m.decorators.length > 0;
-				return s.groupByDecorator  === hasDecorators;
+				return s.groupByDecorator === hasDecorators;
 			} else {
 				const comparer = getStringComparer(s.groupByDecorator);
 				return m.decorators.some((decorator) => comparer(decorator));

--- a/src/rules/sort-class-members.js
+++ b/src/rules/sort-class-members.js
@@ -436,12 +436,14 @@ const comparers = [
 	{
 		property: 'groupByDecorator',
 		value: 10,
-		test: (m, s) => m.decorators.includes(s.groupByDecorator),
-	},
-	{
-		property: 'noDecorator',
-		value: 11,
-		test: (m, s) => (m.decorators.length === 0) === s.noDecorator,
+		test: (m, s) => {
+			if (typeof s.groupByDecorator === 'boolean') {
+				const hasDecorators = m.decorators.length > 0
+				return (s.groupByDecorator && hasDecorators) || (!s.groupByDecorator && !hasDecorators)
+			} else {
+				return m.decorators.includes(s.groupByDecorator)
+			}
+		},
 	},
 	{
 		property: 'accessorPair',

--- a/src/rules/sort-class-members.js
+++ b/src/rules/sort-class-members.js
@@ -451,7 +451,7 @@ const comparers = [
 		test: (m, s) => {
 			if (typeof s.groupByDecorator === 'boolean') {
 				const hasDecorators = m.decorators.length > 0;
-				return (s.groupByDecorator && hasDecorators) || (!s.groupByDecorator && !hasDecorators);
+				return s.groupByDecorator  === hasDecorators;
 			} else {
 				const comparer = getStringComparer(s.groupByDecorator);
 				return m.decorators.some((decorator) => comparer(decorator));

--- a/src/rules/sort-class-members.js
+++ b/src/rules/sort-class-members.js
@@ -439,6 +439,11 @@ const comparers = [
 		test: (m, s) => m.decorators.includes(s.groupByDecorator),
 	},
 	{
+		property: 'noDecorator',
+		value: 11,
+		test: (m, s) => m.decorators.length === 0,
+	},
+	{
 		property: 'accessorPair',
 		value: 20,
 		test: (m, s) =>
@@ -446,7 +451,7 @@ const comparers = [
 	},
 	{
 		property: 'propertyType',
-		value: 11,
+		value: 12,
 		test: (m, s) => m.type === 'property' && s.propertyType === m.propertyType,
 	},
 ];

--- a/src/rules/sort-class-members.js
+++ b/src/rules/sort-class-members.js
@@ -441,7 +441,7 @@ const comparers = [
 	{
 		property: 'noDecorator',
 		value: 11,
-		test: (m, s) => m.decorators.length === 0,
+		test: (m, s) => (m.decorators.length === 0) === s.noDecorator,
 	},
 	{
 		property: 'accessorPair',

--- a/src/rules/sort-class-members.js
+++ b/src/rules/sort-class-members.js
@@ -450,8 +450,8 @@ const comparers = [
 		value: 10,
 		test: (m, s) => {
 			if (typeof s.groupByDecorator === 'boolean') {
-				const hasDecorators = m.decorators.length > 0
-				return (s.groupByDecorator && hasDecorators) || (!s.groupByDecorator && !hasDecorators)
+				const hasDecorators = m.decorators.length > 0;
+				return (s.groupByDecorator && hasDecorators) || (!s.groupByDecorator && !hasDecorators);
 			} else {
 				const comparer = getStringComparer(s.groupByDecorator);
 				return m.decorators.some((decorator) => comparer(decorator));

--- a/test/rules/sort-class-members.spec.js
+++ b/test/rules/sort-class-members.spec.js
@@ -160,8 +160,8 @@ const noDecoratorOptions = [
 		groups: {
 			'no-decorators': [{ decorator: false }],
 		},
-	}
-]
+	},
+];
 
 const decoratorRegexpOptions = [
 	{
@@ -363,7 +363,7 @@ ruleTester.run('sort-class-members', rule, {
 			{
 				code: 'class A { before(){} @something @abc() x = 4; after(){} xyz(){} }',
 				options: decoratorRegexpOptions,
-			}
+			},
 		]),
 
 		// regexp names

--- a/test/rules/sort-class-members.spec.js
+++ b/test/rules/sort-class-members.spec.js
@@ -146,7 +146,7 @@ const noDecoratorOptions = [
 	{
 		order: ['[no-decorators]', 'constructor'],
 		groups: {
-			'no-decorators': [{ noDecorator: true }],
+			'no-decorators': [{ decorator: false }],
 		},
 	}
 ]

--- a/test/rules/sort-class-members.spec.js
+++ b/test/rules/sort-class-members.spec.js
@@ -158,7 +158,7 @@ const noDecoratorOptions = [
 	{
 		order: ['[no-decorators]', 'constructor'],
 		groups: {
-			'no-decorators': [{ decorator: false }],
+			'no-decorators': [{ groupByDecorator: false }],
 		},
 	},
 ];

--- a/test/rules/sort-class-members.spec.js
+++ b/test/rules/sort-class-members.spec.js
@@ -142,6 +142,15 @@ const decoratorOptions = [
 	},
 ];
 
+const noDecoratorOptions = [
+	{
+		order: ['[no-decorators]', 'constructor'],
+		groups: {
+			'no-decorators': [{ noDecorator: true }],
+		},
+	}
+]
+
 const decoratorOptionsAlphabetical = [
 	{
 		order: ['[observables]', '[properties]'],
@@ -321,6 +330,12 @@ ruleTester.run('sort-class-members', rule, {
 			{
 				code: 'class A { @observable bar = 2; @observable foo = 1; @Inject() @observable fuga = 5; baz = 3; constructor(){}; @Inject() hoge = 4; }',
 				options: decoratorOptions,
+			},
+			
+			// class properties without decorators
+			{
+				code: 'class A { private bar = 2; public foo = 3; static x = 55; constructor(){}; }',
+				options: noDecoratorOptions,
 			},
 		]),
 

--- a/test/rules/sort-class-members.spec.js
+++ b/test/rules/sort-class-members.spec.js
@@ -154,11 +154,12 @@ const decoratorOptions = [
 	},
 ];
 
-const noDecoratorOptions = [
+const decoratorBooleanOptions = [
 	{
 		order: ['[no-decorators]', 'constructor'],
 		groups: {
 			'no-decorators': [{ groupByDecorator: false }],
+			'any-decorator': [{ groupByDecorator: true }],
 		},
 	},
 ];
@@ -353,10 +354,10 @@ ruleTester.run('sort-class-members', rule, {
 				options: decoratorOptions,
 			},
 
-			// class properties without decorators
+			// class properties without or without decorators regardless of the name
 			{
-				code: 'class A { private bar = 2; public foo = 3; static x = 55; constructor(){}; }',
-				options: noDecoratorOptions,
+				code: 'class A { bar = 2; foo = 3; static x = 55; constructor(){}; @dec something(){};}',
+				options: decoratorBooleanOptions,
 			},
 			// regexp decorators
 			{ code: 'class A { before(){} @abc() x = 4; after(){} }', options: decoratorRegexpOptions },

--- a/test/rules/sort-class-members.spec.js
+++ b/test/rules/sort-class-members.spec.js
@@ -331,7 +331,7 @@ ruleTester.run('sort-class-members', rule, {
 				code: 'class A { @observable bar = 2; @observable foo = 1; @Inject() @observable fuga = 5; baz = 3; constructor(){}; @Inject() hoge = 4; }',
 				options: decoratorOptions,
 			},
-			
+
 			// class properties without decorators
 			{
 				code: 'class A { private bar = 2; public foo = 3; static x = 55; constructor(){}; }',

--- a/test/rules/sort-class-members.spec.js
+++ b/test/rules/sort-class-members.spec.js
@@ -151,6 +151,15 @@ const noDecoratorOptions = [
 	}
 ]
 
+const decoratorRegexpOptions = [
+	{
+		order: ['before', '[decorator-starts-with-ab]', 'after', '[everything-else]'],
+		groups: {
+			'decorator-starts-with-ab': [{ groupByDecorator: '/ab.+/' }],
+		},
+	},
+];
+
 const decoratorOptionsAlphabetical = [
 	{
 		order: ['[observables]', '[properties]'],
@@ -337,6 +346,12 @@ ruleTester.run('sort-class-members', rule, {
 				code: 'class A { private bar = 2; public foo = 3; static x = 55; constructor(){}; }',
 				options: noDecoratorOptions,
 			},
+			// regexp decorators
+			{ code: 'class A { before(){} @abc() x = 4; after(){} }', options: decoratorRegexpOptions },
+			{
+				code: 'class A { before(){} @something @abc() x = 4; after(){} xyz(){} }',
+				options: decoratorRegexpOptions,
+			}
 		]),
 
 		// regexp names


### PR DESCRIPTION
Adds an option to match class members that have no decorator. It can also be used to match members that have any decorator by setting `noDecorator: false`