### PR TITLE
Add "accessor" and "nonAccessor" options to kind

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Members can be matched to positional slots using several criteria, including nam
 
 - `name`: a string matching the name of the member. If the string starts and ends with `/` it will be interpreted as a regular expression. E.g., `"/_.+/"` will match members whose name starts with an underscore.
 - `type`: `"method"|"property"`. **Note**: Class properties currently require a custom parser like [babel-eslint](https://github.com/babel/babel-eslint).
-- `kind`: `"get"|"set"|"get|set"`. A subtype of `type: "method"` that can match getter or setter methods. `"get|set"` matches both getters and setters.
+- `kind`: `"get"|"set"|"accessor"|"nonAccessor"`. A subtype of `type: "method"` that can match getter or setter methods. `"accessor"` matches both getters and setters, while `"nonAccessor"` matches methods that are neither getters or setters.
 - `propertyType`: A subtype of `type: "property"` that can match the type of the property value. e.g., `propertyType: "ArrowFunctionExpression"` to match properties whose value is initialized to an arrow function.
 - `accessorPair`: `true|false`. True to match only getters and setters that are part of a pair. i.e., only those that have both `get` and `set` methods defined.
 - `static`: `true|false` to restrict the match to static or instance members.

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Members can be matched to positional slots using several criteria, including nam
 
 - `name`: a string matching the name of the member. If the string starts and ends with `/` it will be interpreted as a regular expression. E.g., `"/_.+/"` will match members whose name starts with an underscore.
 - `type`: `"method"|"property"`. **Note**: Class properties currently require a custom parser like [babel-eslint](https://github.com/babel/babel-eslint).
-- `kind`: `"get"|"set"`. A subtype of `type: "method"` that can match getter or setter methods.
+- `kind`: `"get"|"set"|"get|set"`. A subtype of `type: "method"` that can match getter or setter methods. `"get|set"` matches both getters and setters.
 - `propertyType`: A subtype of `type: "property"` that can match the type of the property value. e.g., `propertyType: "ArrowFunctionExpression"` to match properties whose value is initialized to an arrow function.
 - `accessorPair`: `true|false`. True to match only getters and setters that are part of a pair. i.e., only those that have both `get` and `set` methods defined.
 - `static`: `true|false` to restrict the match to static or instance members.

--- a/src/rules/schema.js
+++ b/src/rules/schema.js
@@ -32,7 +32,7 @@ export const sortClassMembersSchema = [
 								name: { type: 'string' },
 								groupByDecorator: { type: 'string' },
 								type: { enum: ['method', 'property'] },
-								kind: { enum: ['get', 'set'] },
+								kind: { enum: ['get', 'set', 'get|set'] },
 								propertyType: { type: 'string' },
 								accessorPair: { type: 'boolean' },
 								sort: { enum: ['alphabetical', 'none'] },

--- a/src/rules/schema.js
+++ b/src/rules/schema.js
@@ -32,7 +32,7 @@ export const sortClassMembersSchema = [
 								name: { type: 'string' },
 								groupByDecorator: { type: 'string' },
 								type: { enum: ['method', 'property'] },
-								kind: { enum: ['get', 'set', 'get|set'] },
+								kind: { enum: ['get', 'set', 'accessor', 'nonAccessor'] },
 								propertyType: { type: 'string' },
 								accessorPair: { type: 'boolean' },
 								sort: { enum: ['alphabetical', 'none'] },

--- a/src/rules/sort-class-members.js
+++ b/src/rules/sort-class-members.js
@@ -433,15 +433,17 @@ const comparers = [
 	{ property: 'override', value: 10, test: (m, s) => s.override == m.override },
 	{ property: 'readonly', value: 10, test: (m, s) => s.readonly == m.readonly },
 	{
-		property: 'kind', value: 10, test: (m, s) => {
+		property: 'kind',
+		value: 10,
+		test: (m, s) => {
 			if (s.kind === 'accessor') {
-				return isAccessor(m)
+				return isAccessor(m);
 			} else if (s.kind === 'nonAccessor') {
-				return !isAccessor(m)
+				return !isAccessor(m);
 			} else {
-				return s.kind === m.kind
+				return s.kind === m.kind;
 			}
-		}
+		},
 	},
 	{
 		property: 'groupByDecorator',

--- a/src/rules/sort-class-members.js
+++ b/src/rules/sort-class-members.js
@@ -432,7 +432,17 @@ const comparers = [
 	{ property: 'abstract', value: 10, test: (m, s) => s.abstract == m.abstract },
 	{ property: 'override', value: 10, test: (m, s) => s.override == m.override },
 	{ property: 'readonly', value: 10, test: (m, s) => s.readonly == m.readonly },
-	{ property: 'kind', value: 10, test: (m, s) => s.kind === 'get|set' ? isAccessor(m) : s.kind === m.kind },
+	{
+		property: 'kind', value: 10, test: (m, s) => {
+			if (s.kind === 'accessor') {
+				return isAccessor(m)
+			} else if (s.kind === 'nonAccessor') {
+				return !isAccessor(m)
+			} else {
+				return s.kind === m.kind
+			}
+		}
+	},
 	{
 		property: 'groupByDecorator',
 		value: 10,

--- a/src/rules/sort-class-members.js
+++ b/src/rules/sort-class-members.js
@@ -432,7 +432,7 @@ const comparers = [
 	{ property: 'abstract', value: 10, test: (m, s) => s.abstract == m.abstract },
 	{ property: 'override', value: 10, test: (m, s) => s.override == m.override },
 	{ property: 'readonly', value: 10, test: (m, s) => s.readonly == m.readonly },
-	{ property: 'kind', value: 10, test: (m, s) => s.kind === m.kind },
+	{ property: 'kind', value: 10, test: (m, s) => s.kind === 'get|set' ? isAccessor(m) : s.kind === m.kind },
 	{
 		property: 'groupByDecorator',
 		value: 10,

--- a/test/rules/sort-class-members.spec.js
+++ b/test/rules/sort-class-members.spec.js
@@ -123,7 +123,13 @@ const accessorOptions = [
 
 const accessorEitherOptions = [
 	{
-		order: [{kind: 'get|set'}, '[everything-else]']
+		order: [{type: 'method', kind: 'accessor'}, '[everything-else]']
+	}
+]
+
+const accessorNeitherOptions = [
+	{
+		order: [{type: 'method', kind: 'nonAccessor'}, '[everything-else]']
 	}
 ]
 
@@ -368,6 +374,11 @@ ruleTester.run('sort-class-members', rule, {
 		{ code: 'class A { get a(){} set a(v){} }', options: accessorEitherOptions },
 		{ code: 'class A { set a(v){} }', options: accessorEitherOptions },
 		{ code: 'class A { get a(){} b(){} }', options: accessorEitherOptions },
+
+		{ code: 'class A { get a(){} }', options: accessorNeitherOptions },
+		{ code: 'class A { get a(){} set a(v){} }', options: accessorNeitherOptions },
+		{ code: 'class A { set a(v){} }', options: accessorNeitherOptions },
+		{ code: 'class A { b(){} get a(){} }', options: accessorNeitherOptions },
 		
 		{
 			code: 'class A { get a(){} set a(v){} }',

--- a/test/rules/sort-class-members.spec.js
+++ b/test/rules/sort-class-members.spec.js
@@ -121,6 +121,12 @@ const accessorOptions = [
 	},
 ];
 
+const accessorEitherOptions = [
+	{
+		order: [{kind: 'get|set'}, '[everything-else]']
+	}
+]
+
 const propertyTypeOptions = [
 	{
 		order: [
@@ -357,6 +363,12 @@ ruleTester.run('sort-class-members', rule, {
 		{ code: 'class A { get a(){} set a(v){} }', options: accessorOptions },
 		{ code: 'class A { set a(v){} }', options: accessorOptions },
 		{ code: 'class A { get a(){} b(){} }', options: accessorOptions },
+
+		{ code: 'class A { get a(){} }', options: accessorEitherOptions },
+		{ code: 'class A { get a(){} set a(v){} }', options: accessorEitherOptions },
+		{ code: 'class A { set a(v){} }', options: accessorEitherOptions },
+		{ code: 'class A { get a(){} b(){} }', options: accessorEitherOptions },
+		
 		{
 			code: 'class A { get a(){} set a(v){} }',
 			options: [{ order: ['everything-else'], accessorPairPositioning: 'getThenSet' }],

--- a/test/rules/sort-class-members.spec.js
+++ b/test/rules/sort-class-members.spec.js
@@ -123,15 +123,15 @@ const accessorOptions = [
 
 const accessorEitherOptions = [
 	{
-		order: [{type: 'method', kind: 'accessor'}, '[everything-else]']
-	}
-]
+		order: [{ type: 'method', kind: 'accessor' }, '[everything-else]'],
+	},
+];
 
 const accessorNeitherOptions = [
 	{
-		order: [{type: 'method', kind: 'nonAccessor'}, '[everything-else]']
-	}
-]
+		order: [{ type: 'method', kind: 'nonAccessor' }, '[everything-else]'],
+	},
+];
 
 const propertyTypeOptions = [
 	{
@@ -379,7 +379,6 @@ ruleTester.run('sort-class-members', rule, {
 		{ code: 'class A { get a(){} set a(v){} }', options: accessorNeitherOptions },
 		{ code: 'class A { set a(v){} }', options: accessorNeitherOptions },
 		{ code: 'class A { b(){} get a(){} }', options: accessorNeitherOptions },
-		
 		{
 			code: 'class A { get a(){} set a(v){} }',
 			options: [{ order: ['everything-else'], accessorPairPositioning: 'getThenSet' }],


### PR DESCRIPTION
Adds a value of `kind` that matches both getters and setters, regardless of whether they are in a pair