### PR TITLE
Add option to sort TypeScript interfaces

### DIFF
--- a/src/rules/schema.js
+++ b/src/rules/schema.js
@@ -13,6 +13,9 @@ export const sortClassMembersSchema = [
 			stopAfterFirstProblem: {
 				type: 'boolean',
 			},
+			sortInterfaces: {
+				type: 'boolean',
+			},
 			accessorPairPositioning: {
 				enum: ['getThenSet', 'setThenGet', 'together', 'any'],
 			},

--- a/src/rules/sort-class-members.js
+++ b/src/rules/sort-class-members.js
@@ -15,6 +15,7 @@ export const sortClassMembersRule = {
 	create: function sortClassMembersRule(context) {
 		const options = context.options[0] || {};
 		const stopAfterFirst = !!options.stopAfterFirstProblem;
+		const sortInterfaces = !!options.sortInterfaces;
 		const accessorPairPositioning = options.accessorPairPositioning || 'getThenSet';
 		const order = options.order || [];
 		const groups = { ...builtInGroups, ...options.groups };
@@ -66,7 +67,9 @@ export const sortClassMembersRule = {
 		};
 
 		rules.ClassExpression = rules.ClassDeclaration;
-		rules.TSInterfaceDeclaration = rules.ClassDeclaration;
+		if (sortInterfaces) {
+			rules.TSInterfaceDeclaration = rules.ClassDeclaration;
+		}
 
 		return rules;
 	},

--- a/src/rules/sort-class-members.js
+++ b/src/rules/sort-class-members.js
@@ -197,7 +197,8 @@ function getMemberInfo(node, sourceCode) {
 		node.type === 'ClassPrivateProperty' ||
 		node.type === 'PropertyDefinition' ||
 		node.type === 'PrivateIdentifier' ||
-		node.type === 'TSAbstractPropertyDefinition'
+		node.type === 'TSAbstractPropertyDefinition' ||
+		node.type === 'TSPropertySignature'
 	) {
 		type = 'property';
 

--- a/src/rules/sort-class-members.js
+++ b/src/rules/sort-class-members.js
@@ -66,6 +66,7 @@ export const sortClassMembersRule = {
 		};
 
 		rules.ClassExpression = rules.ClassDeclaration;
+		rules.TSInterfaceDeclaration = rules.ClassDeclaration;
 
 		return rules;
 	},

--- a/test/rules/sort-class-members.spec.js
+++ b/test/rules/sort-class-members.spec.js
@@ -308,6 +308,27 @@ const typescriptKeywordsOptions = [
 	},
 ];
 
+const typescriptInterfaceOptions = [
+	{
+		order: ['[properties]', '[accessors]', '[non-accessors]'],
+		groups: {
+			accessors: [
+				{
+					type: 'method',
+					kind: 'accessor',
+				},
+			],
+			'non-accessors': [
+				{
+					type: 'method',
+					kind: 'nonAccessor',
+				},
+			],
+		},
+		sortInterfaces: true,
+	},
+];
+
 ruleTester.run('sort-class-members', rule, {
 	valid: [
 		{ code: 'class A {}', options: defaultOptions },
@@ -1006,6 +1027,43 @@ ruleTester.run('sort-class-members', rule, {
 				},
 			],
 			options: typescriptKeywordsOptions,
+			parser: require.resolve('@typescript-eslint/parser'),
+		},
+		// Interface sorting
+		{
+			code: 'interface A { get a(); b; }',
+			output: 'interface A { b; get a();  }',
+			errors: [
+				{
+					message: 'Expected property b to come before getter a.',
+					type: 'TSPropertySignature',
+				},
+			],
+			options: typescriptInterfaceOptions,
+			parser: require.resolve('@typescript-eslint/parser'),
+		},
+		{
+			code: 'interface A { a(); b; }',
+			output: 'interface A { b; a();  }',
+			errors: [
+				{
+					message: 'Expected property b to come before method a.',
+					type: 'TSPropertySignature',
+				},
+			],
+			options: typescriptInterfaceOptions,
+			parser: require.resolve('@typescript-eslint/parser'),
+		},
+		{
+			code: 'interface A { a(); get b(); }',
+			output: 'interface A { get b(); a();  }',
+			errors: [
+				{
+					message: 'Expected getter b to come before method a.',
+					type: 'TSMethodSignature',
+				},
+			],
+			options: typescriptInterfaceOptions,
 			parser: require.resolve('@typescript-eslint/parser'),
 		},
 	],


### PR DESCRIPTION
Adds a `sortInterfaces` option to sort TypeScript interfaces via the `TSInterfaceDeclaration` rule.
Solves https://github.com/bryanrsmith/eslint-plugin-sort-class-members/issues/95.