### PR TITLE
Manually update versions in lockfile to `1.19.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eslint-plugin-sort-class-members",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "eslint-plugin-sort-class-members",
-      "version": "1.18.0",
+      "version": "1.19.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "^7.8.4",


### PR DESCRIPTION
I ran `npm install` locally and noticed changes to `package-lock.json`. Turns out it was for these two lines that identify the package's current version.

(Note that there's no negative effective on any version of the package on npm since the lockfile doesn't get published.)