### PR TITLE
Support ESLint flat configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,28 @@ Add `sort-class-members` to the plugins section of your `.eslintrc` configuratio
 }
 ```
 
+Or, using ESLint's [Flat Config](https://eslint.org/docs/latest/use/configure/configuration-files-new) (`eslint.config.js`):
+
+```js
+import sortClassMembers from "eslint-plugin-sort-class-members";
+
+export default [
+	// Use the default configuration shown above.
+	sortClassMembers.configs["flat/recommended"],
+
+	rules: {
+		// Customize specific configuration properties
+		"sort-class-members/sort-class-members": [
+			2,
+			{
+				"accessorPairPositioning": "together",
+				"stopAfterFirstProblem": true
+			}
+		]
+  }
+];
+```
+
 When using the default configuration (shown above), the following patterns are considered problems:
 
 ```js

--- a/src/index.js
+++ b/src/index.js
@@ -1,30 +1,41 @@
+import * as pkg from '../package.json';
 import { sortClassMembersRule } from './rules/sort-class-members';
 
-// use commonjs default export so ESLint can find the rule
-module.exports = {
-	rules: {
-		'sort-class-members': sortClassMembersRule,
+const plugin = {
+	meta: {
+		name: pkg.name,
+		version: pkg.version,
 	},
-	configs: {
-		recommended: {
-			plugins: ['sort-class-members'],
-			rules: {
-				'sort-class-members/sort-class-members': [
-					2,
-					{
-						order: [
-							'[static-properties]',
-							'[static-methods]',
-							'[properties]',
-							'[conventional-private-properties]',
-							'constructor',
-							'[methods]',
-							'[conventional-private-methods]',
-						],
-						accessorPairPositioning: 'getThenSet',
-					},
-				],
-			},
-		},
-	},
+	configs: {},
+	rules: { 'sort-class-members': sortClassMembersRule },
 };
+
+const rules = {
+	'sort-class-members/sort-class-members': [
+		2,
+		{
+			order: [
+				'[static-properties]',
+				'[static-methods]',
+				'[properties]',
+				'[conventional-private-properties]',
+				'constructor',
+				'[methods]',
+				'[conventional-private-methods]',
+			],
+			accessorPairPositioning: 'getThenSet',
+		},
+	],
+};
+
+plugin.configs.recommended = {
+	plugins: ['sort-class-members'],
+	rules,
+};
+
+plugin.configs['flat/recommended'] = {
+	plugins: { 'sort-class-members': plugin },
+	rules,
+};
+
+module.exports = plugin;


### PR DESCRIPTION
First off, thanks for considering this change! I've used your plugin for quite some time and it's been super helpful.

## Description

(Drawn from commit message on 15ace41)

This PR refactors `./src/index.js` to support ESLint's "new" [flat configuration file](https://eslint.org/docs/latest/use/configure/configuration-files-new) in a non-disruptive, backwards-compatible manner.

The introduction of the flat configuration changed the "shape" of the object that plugins should export. As a result, plugin authors are adding confis with names like `flat/recommended` (as I've done here) for consumers ot use. Rules for the "flat"-prefixed configurations are the same as the legacy config, but with the exported objects conforming to the new "flat" syntax.

I followed the recommendations in [the plugin migration guide](https://eslint.org/docs/latest/extend/plugin-migration-flat-config) with inspiration drawn from [the eslint-plugin-jsdoc's project](https://github.com/gajus/eslint-plugin-jsdoc/blob/main/src/index.js).

Notable changes:

- adds the `meta` key as recommended by ESLint with name and version drawn from `package.json`
- adds a `flat/recommended` configuration matching the rules set by the existing `recommended configuration`

Usage in an `eslint.config.js` file would look like:

```js
import sortClassMembers from "eslint-plugin-sort-class-members";

export default [
  sortClassMembers.configs["flat/recommended"],

  rules: {
    // etc. etc. etc.
  },
];
```

## …and also

I neglected to note the "before" in my commit message. Before this change, using this plugin in a "flat" configuration file is possible, but requires a bit of extra work:

```js
import sortClassMembers from "eslint-plugin-sort-class-members";

export default [
  {
    plugins: { "sort-class-members": sortClassMembers },
    rules: sortClassMembers.configs.recommended.rules,
  },
  
  rules: {
    // etc. etc. etc.
  },
];
```