### PR TITLE
Provide flat config name

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,7 @@ plugin.configs.recommended = {
 };
 
 plugin.configs['flat/recommended'] = {
+	name: 'sort-class-members/flat/recommended'
 	plugins: { 'sort-class-members': plugin },
 	rules,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,7 @@ plugin.configs.recommended = {
 };
 
 plugin.configs['flat/recommended'] = {
-	name: 'sort-class-members/flat/recommended'
+	name: 'sort-class-members/flat/recommended',
 	plugins: { 'sort-class-members': plugin },
 	rules,
 };


### PR DESCRIPTION
When using the ESLint inspector using a name for the flat config will show a nice name to the category.

<img width="501" alt="image" src="https://github.com/user-attachments/assets/8e8a0b71-17d6-4ec2-86a0-f97b178e5bd4">

Not using a name will say anonymous. I think it will be great for debugging and visualising the plugins used.