### PR TITLE
fix: replace deprecated context.getSourceCode() for ESLint 10 compatibility

### DIFF
--- a/src/rules/sort-class-members.js
+++ b/src/rules/sort-class-members.js
@@ -25,7 +25,8 @@ export const sortClassMembersRule = {
 
 		const rules = {
 			ClassDeclaration(node) {
-				let members = getClassMemberInfos(node, context.getSourceCode(), orderedSlots);
+				const sourceCode = context.sourceCode ?? context.getSourceCode();
+				let members = getClassMemberInfos(node, sourceCode, orderedSlots);
 
 				// check for out-of-order and separated get/set pairs
 				const accessorPairProblems = findAccessorPairProblems(members, accessorPairPositioning);
@@ -105,7 +106,7 @@ function reportProblem({
 			if (expected !== 'before') {
 				return fixes; // after almost never occurs, and when it does it causes conflicts
 			}
-			const sourceCode = context.getSourceCode();
+			const sourceCode = context.sourceCode ?? context.getSourceCode();
 			const sourceAfterToken = sourceCode.getTokenAfter(source.node);
 
 			const sourceJSDoc = sourceCode.getCommentsBefore(source.node).slice(-1).pop();


### PR DESCRIPTION
## Summary

Replaces 2 calls to the deprecated `context.getSourceCode()` with `context.sourceCode ?? context.getSourceCode()` in `src/rules/sort-class-members.js`.

### Why

`context.getSourceCode()` was deprecated in ESLint v8.40 and removed in ESLint v10, causing `TypeError: context.getSourceCode is not a function`. The `context.sourceCode` property has been available since v8.40, and the `??` fallback preserves backward compatibility with older versions.

Reference: https://eslint.org/blog/2023/09/preparing-custom-rules-eslint-v9/

### Testing

All 157 existing tests pass with 99.5% code coverage.

Fixes #105